### PR TITLE
Deadlock fix

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -17,4 +17,5 @@ func runCmd(cmd string, args ...string) {
 	if err != nil {
 		log.Fatalf("error running command: %s, %s\n", cmd, err)
 	}
+        defer wg.Done()
 }


### PR DESCRIPTION
It addresses this message when the program exits:

``` bash
$ dockerize date
Fri Nov 14 02:50:47 UTC 2014
fatal error: all goroutines are asleep - deadlock!

goroutine 16 [semacquire]:
sync.runtime_Semacquire(0xc208038288)
    /usr/local/go/src/pkg/runtime/sema.goc:199 +0x30
sync.(*WaitGroup).Wait(0x651980)
    /usr/local/go/src/pkg/sync/waitgroup.go:129 +0x14b
main.main()
    /home/jwilder/go/src/github.com/jwilder/dockerize/dockerize.go:93 +0x983

goroutine 19 [finalizer wait]:
runtime.park(0x415720, 0x6511d0, 0x64fd29)
    /usr/local/go/src/pkg/runtime/proc.c:1369 +0x89
runtime.parkunlock(0x6511d0, 0x64fd29)
    /usr/local/go/src/pkg/runtime/proc.c:1385 +0x3b
runfinq()
    /usr/local/go/src/pkg/runtime/mgc0.c:2644 +0xcf
runtime.goexit()
    /usr/local/go/src/pkg/runtime/proc.c:1445
```
