### PR TITLE
Added support for handling signals.

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -4,13 +4,16 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"os/signal"
 	"syscall"
+	"time"
+
+	"golang.org/x/net/context"
 )
 
-func runCmd(cmd string, args ...string) {
+func runCmd(ctx context.Context, cancel context.CancelFunc, cmd string, args ...string) {
 	defer wg.Done()
 
-	//FIXME: forward signals
 	process := exec.Command(cmd, args...)
 	process.Stdin = os.Stdin
 	process.Stdout = os.Stdout
@@ -19,17 +22,47 @@ func runCmd(cmd string, args ...string) {
 	// start the process
 	err := process.Start()
 	if err != nil {
-		log.Fatalf("error starting command: %s, %s\n", cmd, err)
+		log.Fatalf("Error starting command: `%s` - %s\n", cmd, err)
 	}
 
-	// wait for process to finish
+	wg.Add(1)
+	go func(){
+		defer wg.Done()
+
+		// Setup signaling
+		sigs := make(chan os.Signal)
+		signal.Notify(sigs, syscall.SIGINT, syscall.SIGQUIT)
+
+		select {
+			case sig := <-sigs:
+				log.Printf("Received signal: %s\n", sig)
+				ctx, _ = context.WithTimeout(context.Background(), 10 * time.Second)
+				signalProcessWithTimeout(ctx, process, sig)
+				cancel()
+			case <-ctx.Done():
+				// exit when context is done
+		}
+	}()
+
 	err = process.Wait()
+	cancel()
+	
 	if err == nil {
-		// command completed with exit status 0
-		os.Exit(0)
+		log.Println("Command finished successfully.")
 	} else {
-		// command failed, exit with the same code
-		log.Printf("error running command: %s, %s\n", cmd, err)
+		log.Printf("Command exited with error: %s\n", err)
+		// OPTIMIZE: This could be cleaner
 		os.Exit(err.(*exec.ExitError).Sys().(syscall.WaitStatus).ExitStatus())
+	}
+
+}
+
+func signalProcessWithTimeout(ctx context.Context, process *exec.Cmd, sig os.Signal) {
+	process.Process.Signal(sig) // pretty sure this doesn't do anything. It seems like the signal is automatically sent to the command?
+	process.Wait()
+	select {
+	case <-ctx.Done():
+    log.Println("Killing command due to timeout.")
+    process.Process.Kill()
 	}
 }


### PR DESCRIPTION
If the subprocess does not terminate within 10 seconds of receiving the signal, it will be killed. The program will now exit cleanly on subcommand success (instead of forcing an os.Exit(0).