### PR TITLE
Support setrlimit before executing target

### DIFF
--- a/dockerize.go
+++ b/dockerize.go
@@ -45,6 +45,16 @@ var (
 	waitTimeoutFlag time.Duration
 	dependencyChan  chan struct{}
 
+	rlimitCore      string
+	rlimitCpu       string
+	rlimitData      string
+	rlimitFileSize  string
+	rlimitMemLocked string
+	rlimitNoFile    string
+	rlimitNoProc    string
+	rlimitRss       string
+	rlimitStack     string
+
 	ctx    context.Context
 	cancel context.CancelFunc
 )
@@ -157,6 +167,12 @@ func main() {
 	flag.StringVar(&delimsFlag, "delims", "", `template tag delimiters. default "{{":"}}" `)
 	flag.Var(&waitFlag, "wait", "Host (tcp/tcp4/tcp6/http/https) to wait for before this container starts. Can be passed multiple times. e.g. tcp://db:5432")
 	flag.DurationVar(&waitTimeoutFlag, "timeout", 10*time.Second, "Host wait timeout")
+	flag.StringVar(&rlimitCore, "rlimit-core", "", "core file size limit in bytes")
+	flag.StringVar(&rlimitCpu, "rlimit-cpu", "", "cpu time limit in seconds")
+	flag.StringVar(&rlimitData, "rlimit-data", "", "data seg size limit in bytes")
+	flag.StringVar(&rlimitFileSize, "rlimit-fsize", "", "file size limit limit in bytes")
+	flag.StringVar(&rlimitNoFile, "rlimit-nofile", "", "number of open files limit")
+	flag.StringVar(&rlimitStack, "rlimit-stack", "", "stack size limit in bytes")
 
 	flag.Usage = usage
 	flag.Parse()
@@ -177,6 +193,12 @@ func main() {
 			log.Fatalf("bad delimiters argument: %s. expected \"left:right\"", delimsFlag)
 		}
 	}
+	setLimit("rlimit-core", rlimitCore);
+	setLimit("rlimit-cpu", rlimitCpu);
+	setLimit("rlimit-data", rlimitData);
+	setLimit("rlimit-fsize", rlimitFileSize);
+	setLimit("rlimit-nofile", rlimitNoFile);
+	setLimit("rlimit-stack", rlimitStack);
 	for _, t := range templatesFlag {
 		template, dest := t, ""
 		if strings.Contains(t, ":") {

--- a/rlimit.go
+++ b/rlimit.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"log"
+	"math"
+	"syscall"
+	"strings"
+	"strconv"
+)
+
+func setLimit(rtype string, limit string) {
+	if (limit == "") {
+		return
+	}
+	var resource int
+	switch rtype {
+		case "rlimit-core":
+			resource = syscall.RLIMIT_CORE
+		case "rlimit-cpu":
+			resource = syscall.RLIMIT_CPU
+		case "rlimit-data":
+			resource = syscall.RLIMIT_DATA
+		case "rlimit-fsize":
+			resource = syscall.RLIMIT_FSIZE
+		case "rlimit-nofile":
+			resource = syscall.RLIMIT_NOFILE
+		case "rlimit-stack":
+			resource = syscall.RLIMIT_STACK
+	}
+	var rlim syscall.Rlimit
+	err := syscall.Getrlimit(resource, &rlim)
+	if err != nil {
+		log.Fatalf("Error getrlimit:%s\n", err)
+	}
+	if (strings.ToLower(limit) == "unlimited") {
+		rlim.Cur = math.MaxUint64
+		rlim.Max = math.MaxUint64
+	} else {
+		rlim.Cur, err = strconv.ParseUint(limit, 10, 64)
+		if err != nil {
+			log.Fatalf("Error invalid rlimit %s:%s\n", limit, err)
+		}
+	 	if rlim.Cur >= rlim.Max {
+			rlim.Max = rlim.Cur
+	 	}
+	}
+	err = syscall.Setrlimit(resource, &rlim)
+	if err != nil {
+		log.Fatalf("Error setrlimit:%s\n", err)
+	}
+}


### PR DESCRIPTION
For example user can specify max core file size inside docker to debug in case the contained application crashes. 
Another example is that user can increase max number of open files of dockerized application.