### PR TITLE
Allow dockerize to wait for network dependencies before main command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ It may require that the database URL be read from a python settings file with a 
 `DATABASE_URL` and update the python file when the container starts.
 
 Another use case is when the application logs to specific files on the filesystem and not stdout
-or stderr.  This makes it difficult to troubleshoot the container using the `docker logs` command.
+or stderr. This makes it difficult to troubleshoot the container using the `docker logs` command.
 For example, nginx will log to `/var/log/nginx/access.log` and
-`/var/log/nginx/error.log` by default.  While you can sometimes work around this, it's tedious to find
-the a solution for every application.  dockerize allows you to specify which logs files should
+`/var/log/nginx/error.log` by default. While you can sometimes work around this, it's tedious to find
+the a solution for every application. dockerize allows you to specify which logs files should
 be tailed and where they should be sent.
 
 See [A Simple Way To Dockerize Applications](http://jasonwilder.com/blog/2014/10/13/a-simple-way-to-dockerize-applications/)
@@ -45,10 +45,10 @@ dockerize works by wrapping the call to your application using the `ENTRYPOINT` 
 
 This would generate `/etc/nginx/nginx.conf` from the template located at `/etc/nginx/nginx.tmpl` and
 send `/var/log/nginx/access.log` to `STDOUT` and `/var/log/nginx/error.log` to `STDERR` after running
-`nginx`.
+`nginx`, only after waiting for the `web` host to respond on `tcp 8000`:
 
 ```
-CMD dockerize -template /etc/nginx/nginx.tmpl:/etc/nginx/nginx.conf -stdout /var/log/nginx/access.log -stderr /var/log/nginx/error.log nginx
+CMD dockerize -template /etc/nginx/nginx.tmpl:/etc/nginx/nginx.conf -stdout /var/log/nginx/access.log -stderr /var/log/nginx/error.log -wait tcp://web:8000 nginx
 ```
 
 ### Command-line Options
@@ -60,7 +60,7 @@ $ dockerize -template template1.tmpl:file1.cfg -template template2.tmpl:file3
 
 ```
 
-Templates can be genereated to `STDOUT` by not specifiying a dest:
+Templates can be generated to `STDOUT` by not specifying a dest:
 
 ```
 $ dockerize -template template1.tmpl
@@ -81,6 +81,18 @@ If your file uses `{{` and `}}` as part of it's syntax, you can change the templ
 $ dockerize -delims "<%:%>"
 ```
 
+## Waiting for other dependencies
+
+It is common when using tools like [Docker Compose](https://docs.docker.com/compose/) to depend on services in other linked containers, however oftentimes relying on [links](https://docs.docker.com/compose/compose-file/#links) is not enough - whilst the container itself may have _started_, the _service(s)_ within it may not yet be ready - resulting in shell script hacks to work around race conditions.
+
+Dockerize gives you the ability to wait for services on a specified protocol (`tcp`, `tcp4`, `tcp6`, `http`, and `https`) before starting your application:
+
+```
+$ dockerize -wait tcp://db:5432 -wait http://web:80
+```
+
+See [this issue](https://github.com/docker/compose/issues/374#issuecomment-126312313) for a deeper discussion, and why support isn't and won't be available in the Docker ecosystem itself.
+
 ## Using Templates
 
 Templates use Golang [text/template](http://golang.org/pkg/text/template/). You can access environment
@@ -96,7 +108,7 @@ There are a few built in functions as well:
   * `contains $map $key` - Returns true if a string is within another string
   * `exists $path` - Determines if a file path exists or not. `{{ exists "/etc/default/myapp" }}`
   * `split $string $sep` - Splits a string into an array using a separator string. Alias for [`strings.Split`][go.string.Split]. `{{ split .Env.PATH ":" }}`
-  * `replace $string $old $new $count` - Replaces all occurences of a string within another string. Alias for [`strings.Replace`][go.string.Replace]. `{{ replace .Env.PATH ":" }}`
+  * `replace $string $old $new $count` - Replaces all occurrences of a string within another string. Alias for [`strings.Replace`][go.string.Replace]. `{{ replace .Env.PATH ":" }}`
   * `parseUrl $url` - Parses a URL into it's [protocol, scheme, host, etc. parts][go.url.URL]. Alias for [`url.Parse`][go.url.Parse]
 
 ## License


### PR DESCRIPTION
It is common when using tools like [Docker Compose](https://docs.docker.com/compose/) to depend on services in other linked containers, however oftentimes relying on [links](https://docs.docker.com/compose/compose-file/#links) is not enough - whilst the container itself may have _started_, the _service(s)_ within it may not yet be ready - resulting in shell script hacks to work around race conditions.

This PR gives dockerize the ability to wait for services on a specified protocol (`tcp`, `tcp4`, `tcp6`, `http`, and `https`) before starting the main application:

```
dockerize -wait tcp://db:5432 -wait http://web:80 -timeout 10s somecommand
```
Note the `timeout` is optional and defaults to `10s`.

I've found this to be particularly useful when using Docker Compose as a test harness, where one of the containers needs to test another. Instead of `netcat`ing my way around the problem, I can just wrap the command using `dockerize`.

I also fixed a few minor grammatical/spelling mistakes.

Related links:
* https://github.com/docker/compose/issues/374#issuecomment-126312313
* https://github.com/docker/compose/issues/235