### PR TITLE
add equals function

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ variables within a template with `.Env`.
 There are a few built in functions as well:
 
   * `default $var $default` - Returns a default value for one that does not exist. `{{ default .Env.VERSION "0.1.2" }}`
+  * `equals $val1 $val2` - Returns true if one string equals another, and false otherwise. `{{ if equals .Env.MY_FLAG "1" }}ON{{ else }}OFF{{ end }}`
   * `contains $map $key` - Returns true if a string is within another string
   * `exists $path` - Determines if a file path exists or not. `{{ exists "/etc/default/myapp" }}`
   * `split $string $sep` - Splits a string into an array using a separator string. Alias for [`strings.Split`][go.string.Split]. `{{ split .Env.PATH ":" }}`

--- a/template.go
+++ b/template.go
@@ -29,6 +29,10 @@ func contains(item map[string]string, key string) bool {
 	return false
 }
 
+func equals(left, right string) bool {
+	return left == right
+}
+
 func defaultValue(args ...interface{}) (string, error) {
 	if len(args) == 0 {
 		return "", fmt.Errorf("default called with no values!")
@@ -66,6 +70,7 @@ func parseUrl(rawurl string) *url.URL {
 func generateFile(templatePath, destPath string) bool {
 	tmpl := template.New(filepath.Base(templatePath)).Funcs(template.FuncMap{
 		"contains": contains,
+		"equals":   equals,
 		"exists":   exists,
 		"split":    strings.Split,
 		"replace":  strings.Replace,


### PR DESCRIPTION
I found myself wanting the ability to check the value of an environment variable and generate configs differently depending on the outcome.

Sample use case: You automatically deploy containers to different environments (production, test, VM) and set environment variables in the `docker run` command to indicate to the container which environment it's running in. You want to generate different configs (add/remove/change particular configurations) depending on the environment.

ie. {{ if equals .Env.RUN_ENV "VM" }}replicate=no{{ end }}