### PR TITLE
implement functions atoi and add

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ There are a few built in functions as well:
   * `split $string $sep` - Splits a string into an array using a separator string. Alias for [`strings.Split`][go.string.Split]. `{{ split .Env.PATH ":" }}`
   * `replace $string $old $new $count` - Replaces all occurrences of a string within another string. Alias for [`strings.Replace`][go.string.Replace]. `{{ replace .Env.PATH ":" }}`
   * `parseUrl $url` - Parses a URL into it's [protocol, scheme, host, etc. parts][go.url.URL]. Alias for [`url.Parse`][go.url.Parse]
+  * `atoi $value` - Parses a string $value into an int. `{{ if (gt (atoi .Env.NUM_THREADS) 1) }}`
+  * `add $arg1 $arg` - Performs integer addition. `{{ add (atoi .Env.SHARD_NUM) -1 }}`
 
 ## License
 

--- a/template.go
+++ b/template.go
@@ -64,10 +64,6 @@ func parseUrl(rawurl string) *url.URL {
 	return u
 }
 
-func atoi(s string) (int, error) {
-	return strconv.Atoi(s)
-}
-
 func add(arg1, arg2 int) int {
 	return arg1 + arg2
 }
@@ -80,7 +76,7 @@ func generateFile(templatePath, destPath string) bool {
 		"replace":  strings.Replace,
 		"default":  defaultValue,
 		"parseUrl": parseUrl,
-		"atoi":     atoi,
+		"atoi":     strconv.Atoi,
 		"add":      add,
 	})
 

--- a/template.go
+++ b/template.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"text/template"
@@ -63,6 +64,14 @@ func parseUrl(rawurl string) *url.URL {
 	return u
 }
 
+func atoi(s string) (int, error) {
+	return strconv.Atoi(s)
+}
+
+func add(arg1, arg2 int) int {
+	return arg1 + arg2
+}
+
 func generateFile(templatePath, destPath string) bool {
 	tmpl := template.New(filepath.Base(templatePath)).Funcs(template.FuncMap{
 		"contains": contains,
@@ -71,6 +80,8 @@ func generateFile(templatePath, destPath string) bool {
 		"replace":  strings.Replace,
 		"default":  defaultValue,
 		"parseUrl": parseUrl,
+		"atoi":     atoi,
+		"add":      add,
 	})
 
 	if len(delims) > 0 {


### PR DESCRIPTION
Some additional functionality I found I need for my own use cases, provided via two simple functions. Perhaps this will be useful to others, as well:

`atoi`: Convert a numerical value in `string` form to its representation as type `int`, so that it can be used with Go's `text/template` builtin binary operators (`gt`, `lt`, etc). 
ie: `{{ if (gt (atoi .Env.NUM_THREADS) 1) }}`

`add`: Perform integer addition. My own use case for this was converting between 0-based and 1-based values due to code/config requirements. 
ie. `{{ add (atoi .Env.SHARD_NUM) -1 }}`