### PR TITLE
Add timeout information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ Dockerize gives you the ability to wait for services on a specified protocol (`t
 $ dockerize -wait tcp://db:5432 -wait http://web:80
 ```
 
+### Timeout
+
+You can optionally specify how long to wait for the services to become available by using the `-timeout #` argument (Default: 10 seconds).  If the timeout is reached and the service is still not available, the process exits with status code 1.
+
+```
+$ dockerize -wait tcp://db:5432 -wait http://web:80 -timeout 10
+```
+
 See [this issue](https://github.com/docker/compose/issues/374#issuecomment-126312313) for a deeper discussion, and why support isn't and won't be available in the Docker ecosystem itself.
 
 ## Using Templates


### PR DESCRIPTION
Adds information about the `-timeout` argument to the documentation.