### PR TITLE
Avoid generation if the destination file exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ If your file uses `{{` and `}}` as part of it's syntax, you can change the templ
 $ dockerize -delims "<%:%>"
 ```
 
+If the destination file already exists, dockerize will refuse to overwrite it. The -force flag overrides this behaviour.
+
+```
+$ dockerize -force -template template1.tmpl:file
+```
+
+
 ## Waiting for other dependencies
 
 It is common when using tools like [Docker Compose](https://docs.docker.com/compose/) to depend on services in other linked containers, however oftentimes relying on [links](https://docs.docker.com/compose/compose-file/#links) is not enough - whilst the container itself may have _started_, the _service(s)_ within it may not yet be ready - resulting in shell script hacks to work around race conditions.

--- a/dockerize.go
+++ b/dockerize.go
@@ -188,13 +188,13 @@ func main() {
 			}
 			template, dest = parts[0], parts[1]
 		}
-		 _, err := os.Stat(dest)
+		_, err := os.Stat(dest)
 		if err != nil || forceFlag {
-      generateFile(template, dest)
-    } else {
-      log.Printf("file \"%s\" exists, template not generated", dest)
-    }
-		
+			generateFile(template, dest)
+		} else {
+			log.Printf("file \"%s\" exists, template not generated", dest)
+		}
+
 	}
 
 	waitForDependencies()

--- a/dockerize.go
+++ b/dockerize.go
@@ -39,6 +39,7 @@ var (
 	templatesFlag   sliceVar
 	stdoutTailFlag  sliceVar
 	stderrTailFlag  sliceVar
+	forceFlag       bool
 	delimsFlag      string
 	delims          []string
 	waitFlag        hostFlagsVar
@@ -152,6 +153,7 @@ func main() {
 	flag.BoolVar(&version, "version", false, "show version")
 	flag.BoolVar(&poll, "poll", false, "enable polling")
 	flag.Var(&templatesFlag, "template", "Template (/template:/dest). Can be passed multiple times")
+	flag.BoolVar(&forceFlag, "force", false, "force template generation")
 	flag.Var(&stdoutTailFlag, "stdout", "Tails a file to stdout. Can be passed multiple times")
 	flag.Var(&stderrTailFlag, "stderr", "Tails a file to stderr. Can be passed multiple times")
 	flag.StringVar(&delimsFlag, "delims", "", `template tag delimiters. default "{{":"}}" `)
@@ -186,7 +188,13 @@ func main() {
 			}
 			template, dest = parts[0], parts[1]
 		}
-		generateFile(template, dest)
+		 _, err := os.Stat(dest)
+		if err != nil || forceFlag {
+      generateFile(template, dest)
+    } else {
+      log.Printf("file \"%s\" exists, template not generated", dest)
+    }
+		
 	}
 
 	waitForDependencies()


### PR DESCRIPTION
Hi 
I've added the capability to avoid the generation if the files exists. 
It can be helpful when dockerize is the entrypoint of the container.
