### PR TITLE
Add optional header flag for web requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+### Go template
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+# Created by .ignore support plugin (hsz.mobi)

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ $ dockerize -delims "<%:%>"
 Http headers can be specified for http/https protocols.
 
 ```
-$ dockerize -wait http://web:80 -header "Authorization:Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ=="
+$ dockerize -wait http://web:80 -wait-http-header "Authorization:Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ=="
 ```
 
 ## Waiting for other dependencies

--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ If your file uses `{{` and `}}` as part of it's syntax, you can change the templ
 $ dockerize -delims "<%:%>"
 ```
 
+Http headers can be specified for http/https protocols.
+
+```
+$ dockerize -wait http://web:80 -header "Authorization:Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ=="
+```
+
 ## Waiting for other dependencies
 
 It is common when using tools like [Docker Compose](https://docs.docker.com/compose/) to depend on services in other linked containers, however oftentimes relying on [links](https://docs.docker.com/compose/compose-file/#links) is not enough - whilst the container itself may have _started_, the _service(s)_ within it may not yet be ready - resulting in shell script hacks to work around race conditions.

--- a/dockerize.go
+++ b/dockerize.go
@@ -22,7 +22,7 @@ type Context struct {
 }
 
 type HttpHeader struct {
-	name string
+	name  string
 	value string
 }
 
@@ -47,7 +47,7 @@ var (
 	headersFlag     sliceVar
 	delimsFlag      string
 	delims          []string
-	headers			[]HttpHeader
+	headers         []HttpHeader
 	waitFlag        hostFlagsVar
 	waitTimeoutFlag time.Duration
 	dependencyChan  chan struct{}
@@ -200,7 +200,7 @@ func main() {
 			if len(parts) != 2 {
 				log.Fatalf(errMsg, headersFlag)
 			}
-			headers = append(headers, HttpHeader{ name: parts[0], value: parts[1]})
+			headers = append(headers, HttpHeader{name: parts[0], value: parts[1]})
 		} else {
 			log.Fatalf(errMsg, headersFlag)
 		}

--- a/dockerize.go
+++ b/dockerize.go
@@ -21,6 +21,11 @@ type hostFlagsVar []string
 type Context struct {
 }
 
+type HttpHeader struct {
+	name string
+	value string
+}
+
 func (c *Context) Env() map[string]string {
 	env := make(map[string]string)
 	for _, i := range os.Environ() {
@@ -39,8 +44,10 @@ var (
 	templatesFlag   sliceVar
 	stdoutTailFlag  sliceVar
 	stderrTailFlag  sliceVar
+	headersFlag     sliceVar
 	delimsFlag      string
 	delims          []string
+	headers			[]HttpHeader
 	waitFlag        hostFlagsVar
 	waitTimeoutFlag time.Duration
 	dependencyChan  chan struct{}
@@ -96,7 +103,14 @@ func waitForDependencies() {
 				go func() {
 					defer wg.Done()
 					for {
-						resp, err := http.Get(u.String())
+						client := &http.Client{}
+						req, _ := http.NewRequest("GET", u.String(), nil)
+						if len(headers) > 0 {
+							for _, header := range headers {
+								req.Header.Add(header.name, header.value)
+							}
+						}
+						resp, _ := client.Do(req)
 						if err == nil && resp.StatusCode >= 200 && resp.StatusCode < 300 {
 							log.Printf("Received %d from %s\n", resp.StatusCode, u.String())
 							return
@@ -155,6 +169,7 @@ func main() {
 	flag.Var(&stdoutTailFlag, "stdout", "Tails a file to stdout. Can be passed multiple times")
 	flag.Var(&stderrTailFlag, "stderr", "Tails a file to stderr. Can be passed multiple times")
 	flag.StringVar(&delimsFlag, "delims", "", `template tag delimiters. default "{{":"}}" `)
+	flag.Var(&headersFlag, "header", "HTTP headers, colon separated. e.g \"Accept-Encoding:gzip\". Can be passed multiple times")
 	flag.Var(&waitFlag, "wait", "Host (tcp/tcp4/tcp6/http/https) to wait for before this container starts. Can be passed multiple times. e.g. tcp://db:5432")
 	flag.DurationVar(&waitTimeoutFlag, "timeout", 10*time.Second, "Host wait timeout")
 
@@ -177,6 +192,21 @@ func main() {
 			log.Fatalf("bad delimiters argument: %s. expected \"left:right\"", delimsFlag)
 		}
 	}
+
+	for _, h := range headersFlag {
+		const errMsg = "bad HTTP Headers argument: %s. expected \"headerName:headerValue\""
+		if strings.Contains(h, ":") {
+			parts := strings.Split(h, ":")
+			if len(parts) != 2 {
+				log.Fatalf(errMsg, headersFlag)
+			}
+			headers = append(headers, HttpHeader{ name: parts[0], value: parts[1]})
+		} else {
+			log.Fatalf(errMsg, headersFlag)
+		}
+
+	}
+
 	for _, t := range templatesFlag {
 		template, dest := t, ""
 		if strings.Contains(t, ":") {

--- a/dockerize.go
+++ b/dockerize.go
@@ -169,7 +169,7 @@ func main() {
 	flag.Var(&stdoutTailFlag, "stdout", "Tails a file to stdout. Can be passed multiple times")
 	flag.Var(&stderrTailFlag, "stderr", "Tails a file to stderr. Can be passed multiple times")
 	flag.StringVar(&delimsFlag, "delims", "", `template tag delimiters. default "{{":"}}" `)
-	flag.Var(&headersFlag, "wait-http-header", "HTTP headers, colon separated. e.g \"Accept-Encoding:gzip\". Can be passed multiple times")
+	flag.Var(&headersFlag, "wait-http-header", "HTTP headers, colon separated. e.g \"Accept-Encoding: gzip\". Can be passed multiple times")
 	flag.Var(&waitFlag, "wait", "Host (tcp/tcp4/tcp6/http/https) to wait for before this container starts. Can be passed multiple times. e.g. tcp://db:5432")
 	flag.DurationVar(&waitTimeoutFlag, "timeout", 10*time.Second, "Host wait timeout")
 
@@ -194,13 +194,13 @@ func main() {
 	}
 
 	for _, h := range headersFlag {
-		const errMsg = "bad HTTP Headers argument: %s. expected \"headerName:headerValue\""
+		const errMsg = "bad HTTP Headers argument: %s. expected \"headerName: headerValue\""
 		if strings.Contains(h, ":") {
 			parts := strings.Split(h, ":")
 			if len(parts) != 2 {
 				log.Fatalf(errMsg, headersFlag)
 			}
-			headers = append(headers, HttpHeader{name: parts[0], value: parts[1]})
+			headers = append(headers, HttpHeader{name: strings.TrimSpace(parts[0]), value: strings.TrimSpace(parts[1])})
 		} else {
 			log.Fatalf(errMsg, headersFlag)
 		}

--- a/dockerize.go
+++ b/dockerize.go
@@ -169,7 +169,7 @@ func main() {
 	flag.Var(&stdoutTailFlag, "stdout", "Tails a file to stdout. Can be passed multiple times")
 	flag.Var(&stderrTailFlag, "stderr", "Tails a file to stderr. Can be passed multiple times")
 	flag.StringVar(&delimsFlag, "delims", "", `template tag delimiters. default "{{":"}}" `)
-	flag.Var(&headersFlag, "header", "HTTP headers, colon separated. e.g \"Accept-Encoding:gzip\". Can be passed multiple times")
+	flag.Var(&headersFlag, "wait-http-header", "HTTP headers, colon separated. e.g \"Accept-Encoding:gzip\". Can be passed multiple times")
 	flag.Var(&waitFlag, "wait", "Host (tcp/tcp4/tcp6/http/https) to wait for before this container starts. Can be passed multiple times. e.g. tcp://db:5432")
 	flag.DurationVar(&waitTimeoutFlag, "timeout", 10*time.Second, "Host wait timeout")
 


### PR DESCRIPTION
With help from @andyrbell I've added optional flag 'header' for adding http-headers to waits.