### PR TITLE
Allow template to be a whole directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ $ dockerize -template template1.tmpl
 
 ```
 
+Template may also be a directory. In this case all files within this directory are processed as template and stored with the same name in the destination directory.
+If the destination directory is omitted, the output is sent to `STDOUT`. The files in the source directory are processed in sorted order (as returned by `ioutil.ReadDir`).
+
+```
+$ dockerize -template src_dir:dest_dir
+
+```
+
 
 You can tail multiple files to `STDOUT` and `STDERR` by passing the options multiple times.
 

--- a/dockerize.go
+++ b/dockerize.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -41,17 +42,18 @@ var (
 	poll         bool
 	wg           sync.WaitGroup
 
-	templatesFlag   sliceVar
-	stdoutTailFlag  sliceVar
-	stderrTailFlag  sliceVar
-	headersFlag     sliceVar
-	delimsFlag      string
-	delims          []string
-	headers         []HttpHeader
-	urls            []url.URL
-	waitFlag        hostFlagsVar
-	waitTimeoutFlag time.Duration
-	dependencyChan  chan struct{}
+	templatesFlag    sliceVar
+	templateDirsFlag sliceVar
+	stdoutTailFlag   sliceVar
+	stderrTailFlag   sliceVar
+	headersFlag      sliceVar
+	delimsFlag       string
+	delims           []string
+	headers          []HttpHeader
+	urls             []url.URL
+	waitFlag         hostFlagsVar
+	waitTimeoutFlag  time.Duration
+	dependencyChan   chan struct{}
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -166,7 +168,7 @@ func main() {
 
 	flag.BoolVar(&version, "version", false, "show version")
 	flag.BoolVar(&poll, "poll", false, "enable polling")
-	flag.Var(&templatesFlag, "template", "Template (/template:/dest). Can be passed multiple times")
+	flag.Var(&templatesFlag, "template", "Template (/template:/dest). Can be passed multiple times. Does also support directories")
 	flag.Var(&stdoutTailFlag, "stdout", "Tails a file to stdout. Can be passed multiple times")
 	flag.Var(&stderrTailFlag, "stderr", "Tails a file to stderr. Can be passed multiple times")
 	flag.StringVar(&delimsFlag, "delims", "", `template tag delimiters. default "{{":"}}" `)
@@ -230,7 +232,37 @@ func main() {
 			}
 			template, dest = parts[0], parts[1]
 		}
-		generateFile(template, dest)
+
+		fi, err := os.Stat(template)
+		if err != nil {
+			log.Fatalf("unable to stat %s, error: %s", template, err)
+		}
+		if fi.IsDir() {
+			if dest != "" {
+				fiDest, err := os.Stat(dest)
+				if err != nil {
+					log.Fatalf("unable to stat %s, error: %s", dest, err)
+				}
+				if !fiDest.IsDir() {
+					log.Fatalf("if template is a directory, dest must also be a directory (or stdout)")
+				}
+			}
+
+			files, err := ioutil.ReadDir(template)
+			if err != nil {
+				log.Fatalf("bad directory: %s, error: %s", template, err)
+			}
+
+			for _, file := range files {
+				if dest == "" {
+					generateFile(template+string(os.PathSeparator)+file.Name(), "")
+				} else {
+					generateFile(template+string(os.PathSeparator)+file.Name(), dest+string(os.PathSeparator)+file.Name())
+				}
+			}
+		} else {
+			generateFile(template, dest)
+		}
 	}
 
 	waitForDependencies()

--- a/dockerize.go
+++ b/dockerize.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -238,28 +237,7 @@ func main() {
 			log.Fatalf("unable to stat %s, error: %s", template, err)
 		}
 		if fi.IsDir() {
-			if dest != "" {
-				fiDest, err := os.Stat(dest)
-				if err != nil {
-					log.Fatalf("unable to stat %s, error: %s", dest, err)
-				}
-				if !fiDest.IsDir() {
-					log.Fatalf("if template is a directory, dest must also be a directory (or stdout)")
-				}
-			}
-
-			files, err := ioutil.ReadDir(template)
-			if err != nil {
-				log.Fatalf("bad directory: %s, error: %s", template, err)
-			}
-
-			for _, file := range files {
-				if dest == "" {
-					generateFile(template+string(os.PathSeparator)+file.Name(), "")
-				} else {
-					generateFile(template+string(os.PathSeparator)+file.Name(), dest+string(os.PathSeparator)+file.Name())
-				}
-			}
+			generateDir(template, dest)
 		} else {
 			generateFile(template, dest)
 		}

--- a/template.go
+++ b/template.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/url"
 	"os"
@@ -119,6 +120,33 @@ func generateFile(templatePath, destPath string) bool {
 		}
 		if err := dest.Chown(int(fi.Sys().(*syscall.Stat_t).Uid), int(fi.Sys().(*syscall.Stat_t).Gid)); err != nil {
 			log.Fatalf("unable to chown temp file: %s\n", err)
+		}
+	}
+
+	return true
+}
+
+func generateDir(templateDir, destDir string) bool {
+	if destDir != "" {
+		fiDest, err := os.Stat(destDir)
+		if err != nil {
+			log.Fatalf("unable to stat %s, error: %s", destDir, err)
+		}
+		if !fiDest.IsDir() {
+			log.Fatalf("if template is a directory, dest must also be a directory (or stdout)")
+		}
+	}
+
+	files, err := ioutil.ReadDir(templateDir)
+	if err != nil {
+		log.Fatalf("bad directory: %s, error: %s", templateDir, err)
+	}
+
+	for _, file := range files {
+		if destDir == "" {
+			generateFile(filepath.Join(templateDir, file.Name()), "")
+		} else {
+			generateFile(filepath.Join(templateDir, file.Name()), filepath.Join(destDir, file.Name()))
 		}
 	}
 


### PR DESCRIPTION
Use-case: process complete conf.d directories without the need to list every file separately.
