### PR TITLE
Allow waiting for service on unix socket

### DIFF
--- a/dockerize.go
+++ b/dockerize.go
@@ -83,6 +83,22 @@ func waitForDependencies() {
 			log.Println("Waiting for host:", u.Host)
 
 			switch u.Scheme {
+			case "unix":
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					for {
+						conn, err := net.DialTimeout(u.Scheme, u.Path, waitTimeoutFlag)
+						if err != nil {
+							log.Printf("Problem with dial: %v. Sleeping 5s\n", err.Error())
+							time.Sleep(5 * time.Second)
+						}
+						if conn != nil {
+							log.Println("Connected to", u.String())
+							return
+						}
+					}
+				}()
 			case "tcp", "tcp4", "tcp6":
 				wg.Add(1)
 				go func() {


### PR DESCRIPTION
I need to check that a unix socket is listening (an ssh-agent).
This works, but isn't very nice: it's a copy of the `case "tcp", "tcp4", "tcp6":` where I only changed `u.Host` to `u.Path`.
Not sure if there is a better way to handle this.
