### PR TITLE
Add unix socket wait support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ LDFLAGS:=-X main.buildVersion=$(TAG)
 
 all: dockerize
 
+deps:
+	go get github.com/robfig/glock
+	glock sync -n < GLOCKFILE
+
 dockerize:
 	echo "Building dockerize"
 	go install -ldflags "$(LDFLAGS)"
@@ -14,7 +18,7 @@ dist-clean:
 	rm -rf dist
 	rm -f dockerize-linux-*.tar.gz
 
-dist: dist-clean
+dist: deps dist-clean
 	mkdir -p dist/linux/amd64 && GOOS=linux GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o dist/linux/amd64/dockerize
 	mkdir -p dist/linux/armel && GOOS=linux GOARCH=arm GOARM=5 go build -ldflags "$(LDFLAGS)" -o dist/linux/armel/dockerize
 	mkdir -p dist/linux/armhf && GOOS=linux GOARCH=arm GOARM=6 go build -ldflags "$(LDFLAGS)" -o dist/linux/armhf/dockerize

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ $ dockerize -wait http://web:80 -wait-http-header "Authorization:Basic QWxhZGRpb
 
 It is common when using tools like [Docker Compose](https://docs.docker.com/compose/) to depend on services in other linked containers, however oftentimes relying on [links](https://docs.docker.com/compose/compose-file/#links) is not enough - whilst the container itself may have _started_, the _service(s)_ within it may not yet be ready - resulting in shell script hacks to work around race conditions.
 
-Dockerize gives you the ability to wait for services on a specified protocol (`tcp`, `tcp4`, `tcp6`, `http`, and `https`) before starting your application:
+Dockerize gives you the ability to wait for services on a specified protocol (`tcp`, `tcp4`, `tcp6`, `http`, `https` and `unix`) before starting your application:
 
 ```
 $ dockerize -wait tcp://db:5432 -wait http://web:80


### PR DESCRIPTION
Adds support for waiting for a unix domain socket: `-wait unix:///var/run/docker.sock`.