### PR TITLE
Add alpine linux support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:latest
+MAINTAINER Jason Wilder <mail@jasonwilder.com>
+
+RUN apk -U add openssl
+
+ENV VERSION v0.3.0
+ENV DOWNLOAD_URL https://github.com/jwilder/dockerize/releases/download/$VERSION/dockerize-alpine-linux-amd64-$VERSION.tar.gz
+
+RUN wget -qO- $DOWNLOAD_URL | tar xvz -C /usr/local/bin

--- a/Makefile
+++ b/Makefile
@@ -16,14 +16,17 @@ dockerize:
 
 dist-clean:
 	rm -rf dist
+	rm -f dockerize-alpine-linux-*.tar.gz
 	rm -f dockerize-linux-*.tar.gz
 
 dist: deps dist-clean
+	mkdir -p dist/alpine-linux/amd64 && GOOS=linux GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -a -tags netgo -installsuffix netgo -o dist/alpine-linux/amd64/dockerize
 	mkdir -p dist/linux/amd64 && GOOS=linux GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o dist/linux/amd64/dockerize
 	mkdir -p dist/linux/armel && GOOS=linux GOARCH=arm GOARM=5 go build -ldflags "$(LDFLAGS)" -o dist/linux/armel/dockerize
 	mkdir -p dist/linux/armhf && GOOS=linux GOARCH=arm GOARM=6 go build -ldflags "$(LDFLAGS)" -o dist/linux/armhf/dockerize
 
 release: dist
+	tar -cvzf dockerize-alpine-linux-amd64-$(TAG).tar.gz -C dist/alpine-linux/amd64 dockerize
 	tar -cvzf dockerize-linux-amd64-$(TAG).tar.gz -C dist/linux/amd64 dockerize
 	tar -cvzf dockerize-linux-armel-$(TAG).tar.gz -C dist/linux/armel dockerize
 	tar -cvzf dockerize-linux-armhf-$(TAG).tar.gz -C dist/linux/armhf dockerize

--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSI
     && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 ```
 
+* Docker Base Image
+
+The `jwilder/dockerize` image is a base image that can be used that is based on `alpine linux`.  `dockerize` is installed in the `$PATH` and can be used directly.
+
+```
+FROM jwilder/dockerize:v0.3.0
+...
+ENTRYPOINT dockerize ...
+```
+
 ## Usage
 
 dockerize works by wrapping the call to your application using the `ENTRYPOINT` or `CMD` directives.


### PR DESCRIPTION
This adds alpine linux build targets as well as a base image that
will be accessible from jwilder/dockerize on docker hub.