### PR TITLE
Add a tail-end flag

### DIFF
--- a/dockerize.go
+++ b/dockerize.go
@@ -52,6 +52,7 @@ var (
 	urls             []url.URL
 	waitFlag         hostFlagsVar
 	waitTimeoutFlag  time.Duration
+	tailEndFlag      bool
 	dependencyChan   chan struct{}
 
 	ctx    context.Context
@@ -180,6 +181,7 @@ func main() {
 	flag.Var(&headersFlag, "wait-http-header", "HTTP headers, colon separated. e.g \"Accept-Encoding: gzip\". Can be passed multiple times")
 	flag.Var(&waitFlag, "wait", "Host (tcp/tcp4/tcp6/http/https/unix) to wait for before this container starts. Can be passed multiple times. e.g. tcp://db:5432")
 	flag.DurationVar(&waitTimeoutFlag, "timeout", 10*time.Second, "Host wait timeout")
+	flag.BoolVar(&tailEndFlag, "tail-end", false, "Follow stderr and stdout from end of file")
 
 	flag.Usage = usage
 	flag.Parse()
@@ -261,12 +263,12 @@ func main() {
 
 	for _, out := range stdoutTailFlag {
 		wg.Add(1)
-		go tailFile(ctx, out, poll, os.Stdout)
+		go tailFile(ctx, out, poll, os.Stdout, tailEndFlag)
 	}
 
 	for _, err := range stderrTailFlag {
 		wg.Add(1)
-		go tailFile(ctx, err, poll, os.Stderr)
+		go tailFile(ctx, err, poll, os.Stderr, tailEndFlag)
 	}
 
 	wg.Wait()

--- a/tail.go
+++ b/tail.go
@@ -9,13 +9,18 @@ import (
 	"golang.org/x/net/context"
 )
 
-func tailFile(ctx context.Context, file string, poll bool, dest *os.File) {
+func tailFile(ctx context.Context, file string, poll bool, dest *os.File, end bool) {
 	defer wg.Done()
+	seek := os.SEEK_SET
+	if end {
+		seek = os.SEEK_END
+	}
 	t, err := tail.TailFile(file, tail.Config{
 		Follow: true,
 		ReOpen: true,
 		Poll:   poll,
 		Logger: tail.DiscardingLogger,
+		Location: &tail.SeekInfo{-0, seek},
 	})
 	if err != nil {
 		log.Fatalf("unable to tail %s: %s", "foo", err)


### PR DESCRIPTION
When the tail-end flag is on the stdout and stderr files are followed starting at end of file instead of at the start.

This flag is equivalent to `tail -n 0 ...`