### PR TITLE
Don't flood when using `-wait` with HTTP

### DIFF
--- a/dockerize.go
+++ b/dockerize.go
@@ -104,6 +104,9 @@ func waitForDependencies() {
 						if err == nil && resp.StatusCode >= 200 && resp.StatusCode < 300 {
 							log.Printf("Received %d from %s\n", resp.StatusCode, u.String())
 							return
+						} else {
+							log.Printf("Response from %s is not in 200s. Sleeping 5s\n", u.String())
+							time.Sleep(5 * time.Second)
 						}
 					}
 				}(u)


### PR DESCRIPTION
Based on https://github.com/narfdotpl/dockerize/blob/aa855b40794d18ec6a904e5240c1a8defe0115d2/dockerize.go#L134-L135