### PR TITLE
Make the image usable as a standalone app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,3 +7,6 @@ ENV VERSION v0.3.0
 ENV DOWNLOAD_URL https://github.com/jwilder/dockerize/releases/download/$VERSION/dockerize-alpine-linux-amd64-$VERSION.tar.gz
 
 RUN wget -qO- $DOWNLOAD_URL | tar xvz -C /usr/local/bin
+
+ENTRYPOINT ["dockerize"]
+CMD ["--help"]


### PR DESCRIPTION
After adding a default ENTRYPOINT and CMD,
the base image can be now used as a standalone
tool more easily. Instead of:

`docker run jwilder/dockerize dockerize -wait http://google.com echo 'It works!'`

one can now simply do:

`docker run jwilder/dockerize -wait http://google.com echo 'It works!'`

Running just `docker run jwilder/dockerize` prints the `--help` output.