### PR TITLE
For loop support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
-FROM alpine:latest
+FROM golang:1.8.3-alpine3.6 AS binary
+RUN apk -U add openssl git
+
+ADD . /go/src/github.com/jwilder/dockerize
+WORKDIR /go/src/github.com/jwilder/dockerize
+
+RUN go get github.com/robfig/glock
+RUN glock sync -n < GLOCKFILE
+RUN go install
+
+FROM alpine:3.6
 MAINTAINER Jason Wilder <mail@jasonwilder.com>
 
-RUN apk -U add openssl
-
-ENV VERSION v0.4.0
-ENV DOWNLOAD_URL https://github.com/jwilder/dockerize/releases/download/$VERSION/dockerize-alpine-linux-amd64-$VERSION.tar.gz
-
-RUN wget -qO- $DOWNLOAD_URL | tar xvz -C /usr/local/bin
+COPY --from=binary /go/bin/dockerize /usr/local/bin
 
 ENTRYPOINT ["dockerize"]
 CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ There are a few built in functions as well:
   * `lower $value` - Lowercase a string.
   * `upper $value` - Uppercase a string.
   * `jsonQuery $json $query` - Returns the result of a selection query against a json document.
+  * `loop` - Create for loops.
 
 ### jsonQuery
 
@@ -195,6 +196,27 @@ With the following JSON in `.Env.SERVICES`
 ```
 
 the template expression `jsonQuery .Env.SERVICES "services.[1].port"` returns `9000`.
+
+### loop
+
+`loop` allows for creating for loop within a template.  It takes 1 to 3 arguments.
+
+```
+# Loop from 0...10
+{{ range loop 10 }}
+i = {{ . }}
+{{ end }}
+
+# Loop from 5...10
+{{ range $i := loop 5 10 }}
+i = {{ $i }}
+{{ end }}
+
+# Loop from 5...10 by 2
+{{ range $i := loop 5 10 2 }}
+i = {{ $i }}
+{{ end }}
+```
 
 ## License
 

--- a/template.go
+++ b/template.go
@@ -91,6 +91,30 @@ func jsonQuery(jsonObj string, query string) (interface{}, error) {
 	return res, nil
 }
 
+func loop(args ...int) (<-chan int, error) {
+	var start, stop, step int
+	switch len(args) {
+	case 1:
+		start, stop, step = 0, args[0], 1
+	case 2:
+		start, stop, step = args[0], args[1], 1
+	case 3:
+		start, stop, step = args[0], args[1], args[2]
+	default:
+		return nil, fmt.Errorf("wrong number of arguments, expected 1-3"+
+			", but got %d", len(args))
+	}
+
+	c := make(chan int)
+	go func() {
+		for i := start; i < stop; i += step {
+			c <- i
+		}
+		close(c)
+	}()
+	return c, nil
+}
+
 func generateFile(templatePath, destPath string) bool {
 	tmpl := template.New(filepath.Base(templatePath)).Funcs(template.FuncMap{
 		"contains":  contains,
@@ -105,6 +129,7 @@ func generateFile(templatePath, destPath string) bool {
 		"lower":     strings.ToLower,
 		"upper":     strings.ToUpper,
 		"jsonQuery": jsonQuery,
+		"loop":      loop,
 	})
 
 	if len(delims) > 0 {


### PR DESCRIPTION
This switches the `Dockerfile` to use multi-stage builds and adds a new `loop` template helper to allow for `for` loops.

Fixes #14 