### PR TITLE
Fix #100 allowing to tail named pipes

### DIFF
--- a/tail.go
+++ b/tail.go
@@ -11,11 +11,18 @@ import (
 
 func tailFile(ctx context.Context, file string, poll bool, dest *os.File) {
 	defer wg.Done()
+
+	s, err := os.Stat(file)
+	if err != nil {
+		log.Fatalf("unable to stat %s: %s", file, err)
+	}
+
 	t, err := tail.TailFile(file, tail.Config{
 		Follow: true,
 		ReOpen: true,
 		Poll:   poll,
 		Logger: tail.DiscardingLogger,
+		Pipe:   s.Mode()&os.ModeNamedPipe != 0,
 	})
 	if err != nil {
 		log.Fatalf("unable to tail %s: %s", "foo", err)


### PR DESCRIPTION
As seen in #100, it is impossible to tail a named pipe. This adds the necessary code to configure `hpcloud/tail` when the tailed file is a fifo.