### PR TITLE
Fix 100% cpu util when tailing file

### DIFF
--- a/tail.go
+++ b/tail.go
@@ -18,22 +18,31 @@ func tailFile(ctx context.Context, file string, poll bool, dest *os.File) {
 		Logger: tail.DiscardingLogger,
 	})
 	if err != nil {
-		log.Fatalf("unable to tail %s: %s", "foo", err)
+		log.Fatalf("unable to tail %s: %s", file, err)
 	}
+
+	defer func() {
+		t.Stop()
+		t.Cleanup()
+	}()
 
 	// main loop
 	for {
 		select {
 		// if the channel is done, then exit the loop
 		case <-ctx.Done():
-			t.Stop()
-			t.Cleanup()
 			return
 		// get the next log line and echo it out
 		case line := <-t.Lines:
-			if line != nil {
-				fmt.Fprintln(dest, line.Text)
+			if line == nil {
+				if t.Err() != nil {
+					log.Fatalf("unable to tail %s: %s", file, t.Err())
+				}
+				return
+			} else if line.Err != nil {
+				log.Fatalf("unable to tail %s: %s", file, t.Err())
 			}
+			fmt.Fprintln(dest, line.Text)
 		}
 	}
 }


### PR DESCRIPTION
If the file could not be read or tail had an error, the process
would spin in a look pegging a CPU.

Fixes #107 