### PR TITLE
Checking for creation of logfile, without CPU spin, but bail if too many errors

### DIFF
--- a/tail.go
+++ b/tail.go
@@ -52,7 +52,7 @@ func tailFile(ctx context.Context, file string, poll bool, dest *os.File) {
 			if t.Err() != nil {
 				log.Printf("Warning: unable to tail %s: %s", file, t.Err())
 				errCount++
-				if errCount > 100 {
+				if errCount > 30 {
 					log.Fatalf("Logged %d consecutive errors while tailing. Exiting", errCount)
 				}
 				time.Sleep(2 * time.Second) // Sleep for 2 seconds before retrying


### PR DESCRIPTION
Commit 4c86ed7 fixed the CPU spinning issue, but it also causes dockerize to bail out immediately if a logfile hasn't been created yet by the program to be run when the tail thread goes to look for it. This race condition has broken a lot of my images built using dockerize, and I imagine that it may effect others.

This PR uses time.Sleep() to have the tail thread sleep 2 seconds before retrying, and allows a certain number of retries before bailing out. The number of retries is set for 30, which is gives about a minute for a program to initialize and get its logs going - I'm happy to set it lower if a minute seems too long.

Tailing named pipes is still supported, but the code assumes that if this is a named pipe, mkfifo has already been called before dockerize gets executed.