### PR TITLE
Reap orphan processes

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -1,4 +1,5 @@
 github.com/elgs/gosplitargs e9cf3de21e146ace7f4a8a42af3d51caf7fe2f3b
 github.com/hpcloud/tail faf842bde7ed83bbc3c65a2c454fae39bc29a95f
 github.com/jwilder/gojq 81fa9a608a130323eaf4b4fc00224f7a467ffbd1
+github.com/ramr/go-reaper 35f6a64e44ff062abfcec2d27cef674212d445c0
 golang.org/x/net 749a502dd1eaf3e5bfd4f8956748c502357c0bbe

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 
 	"golang.org/x/net/context"
 )
+import reaper "github.com/ramr/go-reaper"
 
 const defaultWaitRetryInterval = time.Second
 
@@ -295,6 +296,7 @@ func main() {
 	ctx, cancel = context.WithCancel(context.Background())
 
 	if flag.NArg() > 0 {
+		go reaper.Reap()
 		wg.Add(1)
 		go runCmd(ctx, cancel, flag.Arg(0), flag.Args()[1:]...)
 	}


### PR DESCRIPTION
When dockerize is running as PID 1, it has a responsibility to reap zombie processes.
This commit adds a simple library that handles terminated children without further effort.