### PR TITLE
Add json function to output value as JSON

### DIFF
--- a/examples/json/json-example
+++ b/examples/json/json-example
@@ -4,8 +4,8 @@
       "name": "service1",
       "port": 8000
     }, {
-        "name": "service2",
-        "port": 9000
+      "name": "service2",
+      "port": 9000
     }
   ]
 }` }}
@@ -15,11 +15,15 @@
     NAME1={{ jsonQuery $jsonDoc "services.[1].name" }}
     PORT1={{ jsonQuery $jsonDoc "services.[1].port" }}
 
-    {{ range $index, $value := jsonQuery $jsonDoc "services" }}
+    {{ $services := jsonQuery $jsonDoc "services" }}
+    
+    {{ range $index, $value := $services }}
         Index: {{ printf "%v" $index }}
         Name: {{ printf "%v" $value.name }}
         Port: {{ printf "%v" $value.port }}
         ---
     {{end}}
+
+    {{ json $services "    " }}
 
 {{end}}

--- a/template.go
+++ b/template.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	gojson "encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -79,6 +80,25 @@ func isTrue(s string) bool {
 	return false
 }
 
+func json(data interface{}, args ...string) (string, error) {
+	prefix := ""
+	indent := "  "
+
+	if len(args) > 0 {
+		prefix = args[0]
+	}
+
+	if len(args) > 1 {
+		indent = args[1]
+	}
+
+	j, err := gojson.MarshalIndent(data, prefix, indent)
+	if err != nil {
+		return "", err
+	}
+	return string(j), err
+}
+
 func jsonQuery(jsonObj string, query string) (interface{}, error) {
 	parser, err := gojq.NewStringQuery(jsonObj)
 	if err != nil {
@@ -128,6 +148,7 @@ func generateFile(templatePath, destPath string) bool {
 		"isTrue":    isTrue,
 		"lower":     strings.ToLower,
 		"upper":     strings.ToUpper,
+		"json":      json,
 		"jsonQuery": jsonQuery,
 		"loop":      loop,
 	})


### PR DESCRIPTION
For easy representation of json values I've added a JSON function that feeds the value to the json marshaller.

The signature has a variable number of arguments, where the first is the data to marshal, the second (optional) argument is the prefix (to match existing indentation), and the third (optional) argument is the indentation to use.

Contrived example:

```golang
{{ with $jsonDoc := `{
  "services": [
    {
      "name": "service1",
      "port": 8000
    }, {
      "name": "service2",
      "port": 9000
    }
  ]
}` }}
{{- $services := jsonQuery $jsonDoc "services" -}}
{
  "services": {{ json $services "  " "  " }}
}
{{ end }}
```