### PR TITLE
add many functions provided by the sprig lib

### DIFF
--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -2,3 +2,4 @@ github.com/elgs/gosplitargs e9cf3de21e146ace7f4a8a42af3d51caf7fe2f3b
 github.com/hpcloud/tail faf842bde7ed83bbc3c65a2c454fae39bc29a95f
 github.com/jwilder/gojq 81fa9a608a130323eaf4b4fc00224f7a467ffbd1
 golang.org/x/net 749a502dd1eaf3e5bfd4f8956748c502357c0bbe
+github.com/Masterminds/sprig 6f509977777c33eae63b2136d97f7b976cb971cc

--- a/template.go
+++ b/template.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"text/template"
 
+	"github.com/Masterminds/sprig"
 	"github.com/jwilder/gojq"
 )
 
@@ -116,7 +117,7 @@ func loop(args ...int) (<-chan int, error) {
 }
 
 func generateFile(templatePath, destPath string) bool {
-	tmpl := template.New(filepath.Base(templatePath)).Funcs(template.FuncMap{
+	funcMap := template.FuncMap{
 		"contains":  contains,
 		"exists":    exists,
 		"split":     strings.Split,
@@ -130,7 +131,13 @@ func generateFile(templatePath, destPath string) bool {
 		"upper":     strings.ToUpper,
 		"jsonQuery": jsonQuery,
 		"loop":      loop,
-	})
+	}
+	for k, v := range sprig.FuncMap() {
+		if _, ok := funcMap[k]; !ok {
+			funcMap[k] = v
+		}
+	}
+	tmpl := template.New(filepath.Base(templatePath)).Funcs(funcMap)
 
 	if len(delims) > 0 {
 		tmpl = tmpl.Delims(delims[0], delims[1])


### PR DESCRIPTION
namely:

typeOf
dir
toJson
hasPrefix
trunc
wrap
untitle
regexReplaceAll
genSignedCert
hasKey
clean
floor
uuidv4
compact
date_in_zone
tuple
date_modify
first
toPrettyJson
sha1sum
untilStep
splitList
pick
genPrivateKey
slice
quote
ago
date
b32enc
kindIs
pluck
randAlphaNum
until
without
max
typeIs
push
genSelfSignedCert
regexFind
unixEpoch
rest
abbrevboth
nospace
biggest
mul
sub
append
regexReplaceAllLiteral
keys
regexMatch
round
b64enc
mod
squote
nindent
set
randNumeric
trimPrefix
min
reverse
semver
coalesce
trimAll
dateModify
dateInZone
snakecase
b32dec
randAscii
cat
join
float64
trimSuffix
isAbs
values
genCA
kindOf
add1
htmlDate
semverCompare
initial
last
div
substr
repeat
splitn
abbrev
title
plural
hello
list
indent
ceil
sha256sum
wrapWith
swapcase
omit
buildCustomCert
typeIsLike
sortAlpha
trimall
mergeOverwrite
initials
env
htmlDateInZone
toString
expandenv
int64
camelcase
hasSuffix
ext
trim
kebabcase
ternary
uniq
toDate
randAlpha
b64dec
shuffle
regexFindAll
now
dict
prepend
regexSplit
base
empty
fail
derivePassword
adler32sum
has
int
unset
merge
toStrings

a few are NOT imported from sprig, in order to be fully compatible with the older
dockerize versions:

contains
upper
add
split
default
replace
atoi
lower