### PR TITLE
Custom http response status code

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,20 +43,21 @@ var (
 	poll         bool
 	wg           sync.WaitGroup
 
-	templatesFlag     sliceVar
-	templateDirsFlag  sliceVar
-	stdoutTailFlag    sliceVar
-	stderrTailFlag    sliceVar
-	headersFlag       sliceVar
-	delimsFlag        string
-	delims            []string
-	headers           []HttpHeader
-	urls              []url.URL
-	waitFlag          hostFlagsVar
-	waitRetryInterval time.Duration
-	waitTimeoutFlag   time.Duration
-	dependencyChan    chan struct{}
-	noOverwriteFlag   bool
+	templatesFlag      sliceVar
+	templateDirsFlag   sliceVar
+	stdoutTailFlag     sliceVar
+	stderrTailFlag     sliceVar
+	headersFlag        sliceVar
+	delimsFlag         string
+	delims             []string
+	headers            []HttpHeader
+	urls               []url.URL
+	waitFlag           hostFlagsVar
+	waitRetryInterval  time.Duration
+	waitTimeoutFlag    time.Duration
+	expectResponseCode int
+	dependencyChan     chan struct{}
+	noOverwriteFlag    bool
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -135,6 +136,9 @@ func waitForDependencies() {
 						if err != nil {
 							log.Printf("Problem with request: %s. Sleeping %s\n", err.Error(), waitRetryInterval)
 							time.Sleep(waitRetryInterval)
+						} else if resp.StatusCode == expectResponseCode {
+							log.Printf("Received user expected response code %d from %s\n", resp.StatusCode, u.String())
+							return
 						} else if err == nil && resp.StatusCode >= 200 && resp.StatusCode < 300 {
 							log.Printf("Received %d from %s\n", resp.StatusCode, u.String())
 							return
@@ -220,6 +224,7 @@ func main() {
 	flag.Var(&waitFlag, "wait", "Host (tcp/tcp4/tcp6/http/https/unix/file) to wait for before this container starts. Can be passed multiple times. e.g. tcp://db:5432")
 	flag.DurationVar(&waitTimeoutFlag, "timeout", 10*time.Second, "Host wait timeout")
 	flag.DurationVar(&waitRetryInterval, "wait-retry-interval", defaultWaitRetryInterval, "Duration to wait before retrying")
+	flag.IntVar(&expectResponseCode, "expect-response-code", 200, "Http response code expected")
 
 	flag.Usage = usage
 	flag.Parse()

--- a/main.go
+++ b/main.go
@@ -139,7 +139,7 @@ func waitForDependencies() {
 						} else if resp.StatusCode == expectResponseCode {
 							log.Printf("Received user expected response code %d from %s\n", resp.StatusCode, u.String())
 							return
-						} else if err == nil && resp.StatusCode >= 200 && resp.StatusCode < 300 {
+						} else if err == nil && expectResponseCode == 0 && resp.StatusCode >= 200 && resp.StatusCode < 300 {
 							log.Printf("Received %d from %s\n", resp.StatusCode, u.String())
 							return
 						} else {
@@ -224,7 +224,7 @@ func main() {
 	flag.Var(&waitFlag, "wait", "Host (tcp/tcp4/tcp6/http/https/unix/file) to wait for before this container starts. Can be passed multiple times. e.g. tcp://db:5432")
 	flag.DurationVar(&waitTimeoutFlag, "timeout", 10*time.Second, "Host wait timeout")
 	flag.DurationVar(&waitRetryInterval, "wait-retry-interval", defaultWaitRetryInterval, "Duration to wait before retrying")
-	flag.IntVar(&expectResponseCode, "expect-response-code", 200, "Http response code expected")
+	flag.IntVar(&expectResponseCode, "expect-response-code", 0, "Http response code expected")
 
 	flag.Usage = usage
 	flag.Parse()


### PR DESCRIPTION
Allows a user to determine an http response code to exit from the wait.
This is useful to test error scenarios where the dependencies of service may be down.