### PR TITLE
Update to latest Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8.3-alpine3.6 AS binary
+FROM golang:1.13.7-alpine3.11 AS binary
 RUN apk -U add openssl git
 
 ADD . /go/src/github.com/jwilder/dockerize
@@ -8,7 +8,7 @@ RUN go get github.com/robfig/glock
 RUN glock sync -n < GLOCKFILE
 RUN go install
 
-FROM alpine:3.6
+FROM alpine:3.11
 MAINTAINER Jason Wilder <mail@jasonwilder.com>
 
 COPY --from=binary /go/bin/dockerize /usr/local/bin


### PR DESCRIPTION
This PR updates `Dockerfile` to use images `golang:1.13.7-alpine3.11` and `alpine3.11`, the latest versions of each.

I was able to build the Docker image and execute `dockerize` inside the resulting container.  It seems to be working okay; and I don't see any established procedure for testing it.