### PR TITLE
Close connections

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -137,9 +139,14 @@ func waitForDependencies() {
 							time.Sleep(waitRetryInterval)
 						} else if err == nil && resp.StatusCode >= 200 && resp.StatusCode < 300 {
 							log.Printf("Received %d from %s\n", resp.StatusCode, u.String())
+							// dispose the response body and close it.
+							io.Copy(ioutil.Discard, resp.Body)
+							resp.Body.Close()
 							return
 						} else {
 							log.Printf("Received %d from %s. Sleeping %s\n", resp.StatusCode, u.String(), waitRetryInterval)
+							io.Copy(ioutil.Discard, resp.Body)
+							resp.Body.Close()
 							time.Sleep(waitRetryInterval)
 						}
 					}

--- a/main.go
+++ b/main.go
@@ -180,6 +180,7 @@ func waitForSocket(scheme, addr string, timeout time.Duration) {
 			}
 			if conn != nil {
 				log.Printf("Connected to %s://%s\n", scheme, addr)
+				conn.Close()
 				return
 			}
 		}


### PR DESCRIPTION
Hi. This PR enables close test connections and HTTP response.

dockerize keeps a test TCP connection while running, but if the server cannot accept multiple TCP connections, the test connection fills the server's slot. It should be closed.

dockerize does not read HTTP response body and does not close it now.
When an unread response body exists, http.Client cannot reuse the TCP connection for the next request.