### PR TITLE
Check if file exists and then wait, instead of other way around

### DIFF
--- a/main.go
+++ b/main.go
@@ -95,6 +95,10 @@ func waitForDependencies() {
 					ticker := time.NewTicker(waitRetryInterval)
 					defer ticker.Stop()
 					var err error
+					if _, err = os.Stat(u.Path); err == nil {
+						log.Printf("File %s had been generated\n", u.String())
+						return
+					}
 					for range ticker.C {
 						if _, err = os.Stat(u.Path); err == nil {
 							log.Printf("File %s had been generated\n", u.String())


### PR DESCRIPTION
When the file exists, it would be great to immediately return instead of waiting for the first tick of refresh interval.