### PR TITLE
chore: upgrade go, improve dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,18 @@
-FROM golang:1.17-alpine3.15 AS binary
+FROM golang:1.19.1-alpine3.16 AS binary
 RUN apk --no-cache --update add openssl git
 
 WORKDIR /go/src/github.com/jwilder/dockerize
 COPY *.go go.* /go/src/github.com/jwilder/dockerize/
 
 ENV GO111MODULE=on
-RUN go mod tidy
-RUN go install
+ENV CGO_ENABLED=0
 
-FROM alpine:3.15
+RUN --mount=type=cache,mode=0777,target=/go/pkg/mod \
+    --mount=type=cache,mode=0777,target=/root/.cache/build \
+    go mod tidy && \
+    go install
+
+FROM alpine:3.16.2
 LABEL MAINTAINER="Jason Wilder <mail@jasonwilder.com>"
 
 COPY --from=binary /go/bin/dockerize /usr/local/bin

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jwilder/dockerize
 
-go 1.17
+go 1.19
 
 require (
 	github.com/Masterminds/sprig v2.22.0+incompatible


### PR DESCRIPTION
### Changes
- Bump go version to `1.19`.
- Reduced layer in dockerfile.