### PR TITLE
Fix alpine install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ ENV DOCKERIZE_VERSION v0.7.0
 
 RUN apk update --no-cache \
     && apk add --no-cache wget openssl \
-    && wget -O - https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz | tar xzf - -C /usr/local/bin \
+    && wget -O - https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz | tar xzf - -C /usr/local/bin \
     && apk del wget
 ```
 


### PR DESCRIPTION
If I'm not mistaken, the installation instructions for Alpine Linux use the wrong package name.