### PR TITLE
Update dockerfile base image to resolve Go stdlib CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.1 AS binary
+FROM golang:1.21.11 AS binary
 
 WORKDIR /go/src/github.com/jwilder/dockerize
 COPY *.go go.* /go/src/github.com/jwilder/dockerize/


### PR DESCRIPTION
__Addresses:__
- CVE-2024-24790 (https://nvd.nist.gov/vuln/detail/CVE-2024-24790)
- CVE-2023-45283 (https://nvd.nist.gov/vuln/detail/CVE-2023-45283)
- CVE-2023-39325 (https://nvd.nist.gov/vuln/detail/CVE-2023-39325)

__Changes:__
- Bumped base image from `golang:1.21.1` to `golang:1.21.11`