### PR TITLE
Add Dependabot for version upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,4 @@ updates:
   - package-ecosystem: gomod
     directory: /
     schedule:
-      interval: weekly
+      interval: "weekly"

--- a/go.mod
+++ b/go.mod
@@ -25,3 +25,5 @@ require (
 	gopkg.in/fsnotify.v1 v1.4.7 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 )
+
+replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.16


### PR DESCRIPTION
In the light of recent tickets and according fixes, I thought it might be prudent to add a dependabot config for version updates.

Since Dependabot also allows for security updates, you might want to look into that, too. This would prevent at least minor issues to be solved by a simple PR.

Let me know if you could also use some GitHub Actions for publishing the new versions of dockerize to Docker Hub.