### PR TITLE
fix: upgrade to Go 1.25.1 to address CVE-2025-47910

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25 AS binary
+FROM golang:1.25.1 AS binary
 
 WORKDIR /go/src/github.com/jwilder/dockerize
 COPY *.go go.* /go/src/github.com/jwilder/dockerize/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jwilder/dockerize
 
-go 1.25
+go 1.25.1
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,6 @@ github.com/elgs/gosplitargs v0.0.0-20241205072753-cbd889c0f906 h1:Gfn+NcN3eAVFLX
 github.com/elgs/gosplitargs v0.0.0-20241205072753-cbd889c0f906/go.mod h1:w1WVg5EhY8yy+53iAGOaUp4JxlmV24K3D21BpFgxqcY=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
-github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=


### PR DESCRIPTION
This update resolves CVE-2025-47910 (MEDIUM severity) in the Go stdlib by upgrading from Go 1.25.0 to Go 1.25.1.

Changes:
- Update go.mod to use Go 1.25.1
- Update Dockerfile base image to golang:1.25.1
- Update go.sum with refreshed dependencies