### PR TITLE
fix: upgrade to Go 1.25.3 to address multiple CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.1 AS binary
+FROM golang:1.25.3 AS binary
 
 WORKDIR /go/src/github.com/jwilder/dockerize
 COPY *.go go.* /go/src/github.com/jwilder/dockerize/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jwilder/dockerize
 
-go 1.25.1
+go 1.25.3
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0


### PR DESCRIPTION
This update resolves multiple security vulnerabilities in the Go stdlib by upgrading from Go 1.25.1 to Go 1.25.3.

Security fixes:
- CVE-2025-61725 (HIGH)
- CVE-2025-58188 (HIGH)
- CVE-2025-47912 (MEDIUM)
- CVE-2025-58186 (MEDIUM)
- CVE-2025-61724 (MEDIUM)
- CVE-2025-61723 (MEDIUM)
- CVE-2025-58189 (MEDIUM)
- CVE-2025-58185 (MEDIUM)
- CVE-2025-58187 (MEDIUM)
- CVE-2025-58183 (LOW)

Changes:
- Update go.mod to use Go 1.25.3
- Update Dockerfile base image to golang:1.25.3

Hey @jwilder can we also get a release? so we can get the Docker image from the registry?