### PR TITLE
chore: prepare for v0.9.7 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-dockerize ![version v0.9.6](https://img.shields.io/badge/version-v0.9.6-brightgreen.svg) ![License MIT](https://img.shields.io/badge/license-MIT-blue.svg)
+dockerize ![version v0.9.7](https://img.shields.io/badge/version-v0.9.7-brightgreen.svg) ![License MIT](https://img.shields.io/badge/license-MIT-blue.svg)
 =============
 
 Utility to simplify running applications in docker containers.
@@ -28,13 +28,13 @@ See [A Simple Way To Dockerize Applications](http://jasonwilder.com/blog/2014/10
 
 Download the latest version in your container:
 
-* [linux/amd64](https://github.com/jwilder/dockerize/releases/download/v0.9.6/dockerize-linux-amd64-v0.9.6.tar.gz)
-* [linux/armel](https://github.com/jwilder/dockerize/releases/download/v0.9.6/dockerize-linux-armel-v0.9.6.tar.gz)
-* [linux/arm64](https://github.com/jwilder/dockerize/releases/download/v0.9.6/dockerize-linux-arm64-v0.9.6.tar.gz)
-* [linux/armhf](https://github.com/jwilder/dockerize/releases/download/v0.9.6/dockerize-linux-armhf-v0.9.6.tar.gz)
-* [alpine/amd64](https://github.com/jwilder/dockerize/releases/download/v0.9.6/dockerize-alpine-linux-amd64-v0.9.6.tar.gz)
-* [darwin/amd64](https://github.com/jwilder/dockerize/releases/download/v0.9.6/dockerize-darwin-amd64-v0.9.6.tar.gz)
-* [darwin/arm64](https://github.com/jwilder/dockerize/releases/download/v0.9.6/dockerize-darwin-arm64-v0.9.6.tar.gz)
+* [linux/amd64](https://github.com/jwilder/dockerize/releases/download/v0.9.7/dockerize-linux-amd64-v0.9.7.tar.gz)
+* [linux/armel](https://github.com/jwilder/dockerize/releases/download/v0.9.7/dockerize-linux-armel-v0.9.7.tar.gz)
+* [linux/arm64](https://github.com/jwilder/dockerize/releases/download/v0.9.7/dockerize-linux-arm64-v0.9.7.tar.gz)
+* [linux/armhf](https://github.com/jwilder/dockerize/releases/download/v0.9.7/dockerize-linux-armhf-v0.9.7.tar.gz)
+* [alpine/amd64](https://github.com/jwilder/dockerize/releases/download/v0.9.7/dockerize-alpine-linux-amd64-v0.9.7.tar.gz)
+* [darwin/amd64](https://github.com/jwilder/dockerize/releases/download/v0.9.7/dockerize-darwin-amd64-v0.9.7.tar.gz)
+* [darwin/arm64](https://github.com/jwilder/dockerize/releases/download/v0.9.7/dockerize-darwin-arm64-v0.9.7.tar.gz)
 
 
 ### Docker Base Image
@@ -50,7 +50,7 @@ ENTRYPOINT dockerize ...
 ### Ubuntu Images
 
 ``` Dockerfile
-ENV DOCKERIZE_VERSION v0.9.6
+ENV DOCKERIZE_VERSION v0.9.7
 
 RUN apt-get update \
     && apt-get install -y wget \
@@ -62,7 +62,7 @@ RUN apt-get update \
 ### For Alpine Images:
 
 ``` Dockerfile
-ENV DOCKERIZE_VERSION v0.9.6
+ENV DOCKERIZE_VERSION v0.9.7
 
 RUN apk update --no-cache \
     && apk add --no-cache wget openssl \


### PR DESCRIPTION
Update all version references in README.md from v0.9.6 to v0.9.7 so it's ready to create the release

This PR prepares the repository for the v0.9.7 release which includes:
- Upgrade to Go 1.25.3 (merged in #253 and #254)
- Security fixes for 11 CVEs (2 HIGH, 8 MEDIUM, 1 LOW)

## Changes
- Update version badge to v0.9.7
- Update all download URLs to point to v0.9.7
- Update DOCKERIZE_VERSION environment variable examples

Closes #253
Closes #254
Closes #251
Closes #240 