### PR TITLE
Build artifacts for riscv64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,3 +151,13 @@ jobs:
           asset_path: ./dockerize-linux-s390x-${{ steps.tag.outputs.tag }}.tar.gz
           asset_name: dockerize-linux-s390x-${{ steps.tag.outputs.tag }}.tar.gz
           asset_content_type: application/gzip
+
+      - name: Upload Linux RISCV64
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./dockerize-linux-riscv64-${{ steps.tag.outputs.tag }}.tar.gz
+          asset_name: dockerize-linux-riscv64-${{ steps.tag.outputs.tag }}.tar.gz
+          asset_content_type: application/gzip

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ dist: deps dist-clean
 	mkdir -p dist/darwin/amd64 && GOOS=darwin GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o dist/darwin/amd64/dockerize
 	mkdir -p dist/darwin/amd64 && GOOS=darwin GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o dist/darwin/arm64/dockerize
 	mkdir -p dist/linux/s390x && GOOS=linux GOARCH=s390x go build -ldflags "$(LDFLAGS)" -o dist/linux/s390x/dockerize
+	mkdir -p dist/linux/riscv64 && GOOS=linux GOARCH=riscv64 go build -ldflags "$(LDFLAGS)" -o dist/linux/riscv64/dockerize
 
 release: dist
 	tar -cvzf dockerize-alpine-linux-amd64-$(TAG).tar.gz -C dist/alpine-linux/amd64 dockerize
@@ -43,3 +44,4 @@ release: dist
 	tar -cvzf dockerize-darwin-amd64-$(TAG).tar.gz -C dist/darwin/amd64 dockerize
 	tar -cvzf dockerize-darwin-arm64-$(TAG).tar.gz -C dist/darwin/arm64 dockerize
 	tar -cvzf dockerize-linux-s390x-$(TAG).tar.gz -C dist/linux/s390x dockerize
+	tar -cvzf dockerize-linux-riscv64-$(TAG).tar.gz -C dist/linux/riscv64 dockerize


### PR DESCRIPTION
Hi there.

Recently, riscv64 has gained widespread adoption, so we can consider adding riscv64 support to this repository. Since Go upstream has excellent support for riscv64, we don't need to make many modifications to implement the related support.

I tried running the CI in my fork, and the results show everything went smoothly.

1. [Go Build and Test](https://github.com/ffgan/dockerize/actions/runs/19204560766)
2. [Release](https://github.com/ffgan/dockerize/actions/runs/19204560774)

If you have any questions about this, please feel free to @ me directly. I'm happy to answer any questions you may have.

---
**Other Info**
Co-authored by: nijincheng@iscas.ac.cn;