### PR TITLE
Update Go from 1.25.9 to 1.25.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.9 AS binary
+FROM golang:1.25.10 AS binary
 
 WORKDIR /go/src/github.com/jwilder/dockerize
 COPY *.go go.* /go/src/github.com/jwilder/dockerize/

--- a/exec.go
+++ b/exec.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"log"
 	"os"
@@ -9,7 +10,6 @@ import (
 	"syscall"
 	"time"
 
-	"golang.org/x/net/context"
 )
 
 func runCmd(ctx context.Context, cancel context.CancelFunc, cmd string, args ...string) {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jwilder/dockerize
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io"
@@ -13,7 +14,6 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
 )
 
 const defaultWaitRetryInterval = time.Second

--- a/tail.go
+++ b/tail.go
@@ -1,13 +1,13 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
 	"time"
 
 	"github.com/hpcloud/tail"
-	"golang.org/x/net/context"
 )
 
 func tailFile(ctx context.Context, file string, poll bool, dest *os.File) {


### PR DESCRIPTION
Addresses the below CVEs:
CVE-2026-33811
CVE-2026-33814
CVE-2026-39820
CVE-2026-39836
CVE-2026-42499
CVE-2026-42501
CVE-2026-39823
CVE-2026-39826
CVE-2026-39817
CVE-2026-39819
CVE-2026-39825