### PR TITLE
Add missing .github/CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @runtimed


### PR DESCRIPTION
## What was changed
Added a `.github/CODEOWNERS` file to the repository.

## Why
The repository was missing a `CODEOWNERS` file, which is used by GitHub to automatically request reviews from the appropriate teams or individuals when pull requests modify relevant code paths. Without this file, there is no automated ownership enforcement for code review.

## How to verify
1. Confirm `.github/CODEOWNERS` exists and contains valid ownership rules.
2. Open a pull request modifying a covered path and verify GitHub suggests the correct reviewers.