### PR TITLE
Add missing CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code owners for this repository.
+* @jwilder


### PR DESCRIPTION
## What

This change adds a `.github/CODEOWNERS` file to the repository.

## Why

The repository was missing a CODEOWNERS file, which was flagged as a finding (1 finding addressed). Without a CODEOWNERS file:
- There are no automatically requested reviewers when pull requests are opened.
- Code ownership and review responsibilities are unclear.
- Required-review enforcement tied to code owners cannot function.

Adding this file establishes clear ownership and ensures the appropriate reviewers are automatically requested on relevant pull requests.

## How to Verify

1. Confirm the `.github/CODEOWNERS` file exists in the repository.
2. Validate that GitHub recognizes the file: navigate to **Settings → Branches → Branch protection rules** (or view the file in the GitHub UI, which will show a warning if the syntax is invalid).
3. Open a test pull request and confirm that the expected owners are automatically requested as reviewers.