### PR TITLE
ci: enable build cache in CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+          cache: true
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
@@ -38,6 +39,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+          cache: true
 
       - name: Run tests
         run: go test -v -race -coverprofile=coverage.out ./...
@@ -59,6 +61,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+          cache: true
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
@@ -82,6 +85,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+          cache: true
 
       - name: Build
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+          cache: true
 
       - name: Calculate next version
         id: version


### PR DESCRIPTION
## What

Added build caching to the CI and release GitHub Actions workflows. This change touches two files:

- `.github/workflows/ci.yml` — added cache configuration (4 lines)
- `.github/workflows/release.yml` — enabled caching (1 line)

## Why

Both workflows were running without a build cache, meaning every CI and release run recompiled dependencies and build artifacts from scratch. This resulted in:

- Longer pipeline run times
- Wasted CI minutes and compute resources
- Slower feedback loops on pull requests

Enabling the build cache lets subsequent runs reuse previously compiled artifacts and downloaded dependencies, addressing the "Missing build cache in CI" finding.

## How to verify

1. Trigger a CI run on this branch (or open/push to a PR) and let it complete once to populate the cache.
2. Trigger a second run and confirm the workflow logs show a cache hit (e.g., a "Cache restored" / "Cache hit" step) rather than rebuilding from scratch.
3. Compare the total job duration between the first (cold) and second (warm) runs — the warm run should be measurably faster.
4. Repeat the same check for the release workflow to confirm the cache step is active there as well.