### PR TITLE
Remove unused templateDirsFlag declaration in main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,7 +45,6 @@ var (
 	wg           sync.WaitGroup
 
 	templatesFlag     sliceVar
-	templateDirsFlag  sliceVar
 	stdoutTailFlag    sliceVar
 	stderrTailFlag    sliceVar
 	headersFlag       sliceVar


### PR DESCRIPTION
## What
Removed the `templateDirsFlag` variable declaration from `main.go`. This was a single-line deletion of a variable that was declared but never referenced anywhere in the code.

## Why
In Go, a declared-but-unused local variable causes a compile-time error, and unused package-level declarations represent dead code that adds noise and confusion. The static analysis flagged `templateDirsFlag` as declared but never used (1 finding). Removing it cleans up the codebase and eliminates the warning/error.

## How to verify
1. Build the project to confirm it compiles cleanly:
   ```
   go build ./...
   ```
2. Run the linter/vet to confirm the finding is resolved:
   ```
   go vet ./...
   ```
3. Confirm no other references to `templateDirsFlag` exist:
   ```
   grep -rn "templateDirsFlag" .
   ```
   (should return no results)
4. Run the existing test suite to ensure no behavior changed:
   ```
   go test ./...
   ```