### PR TITLE
Remove unused package-level `dependencyChan` variable

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,7 +56,6 @@ var (
 	waitFlag          hostFlagsVar
 	waitRetryInterval time.Duration
 	waitTimeoutFlag   time.Duration
-	dependencyChan    chan struct{}
 	noOverwriteFlag   bool
 
 	ctx    context.Context


### PR DESCRIPTION
## What

Removed the package-level `dependencyChan` declaration from `main.go`. This variable was declared but never referenced anywhere in the codebase.

## Why

The unused declaration was flagged by static analysis (1 finding). Dead code like this adds noise, can mislead readers into thinking the channel is part of an active code path, and may trigger linter warnings or CI failures. Removing it keeps the package clean and the intent of the code clear.

## How to verify

1. Confirm the variable is no longer present:
   ```
   grep -n "dependencyChan" main.go
   ```
   This should return no results.
2. Build the project to ensure nothing depended on it:
   ```
   go build ./...
   ```
3. Run the linter/static analysis to confirm the finding is resolved:
   ```
   go vet ./...
   ```

All builds and checks should pass with no references to `dependencyChan` remaining.