### PR TITLE
Add unit tests for main, tail, and template packages

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,8 +1,18 @@
 package main
 
 import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -145,4 +155,150 @@ func TestLoop(t *testing.T) {
 
 	_, err = loop(1, 2, 3, 4)
 	assert.Error(t, err)
+}
+
+func TestWaitForSocketConnectsToTCPServer(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.NoError(t, err)
+	defer ln.Close()
+
+	oldRetry := waitRetryInterval
+	oldTimeout := waitTimeoutFlag
+	wg = sync.WaitGroup{}
+	waitRetryInterval = 10 * time.Millisecond
+	waitTimeoutFlag = 200 * time.Millisecond
+	defer func() {
+		wg = sync.WaitGroup{}
+		waitRetryInterval = oldRetry
+		waitTimeoutFlag = oldTimeout
+	}()
+
+	acceptDone := make(chan struct{})
+	go func() {
+		defer close(acceptDone)
+		conn, err := ln.Accept()
+		if err == nil {
+			conn.Close()
+		}
+	}()
+
+	waitForSocket("tcp", ln.Addr().String(), waitTimeoutFlag)
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for socket connection")
+	}
+
+	select {
+	case <-acceptDone:
+	case <-time.After(time.Second):
+		t.Fatal("server did not accept test connection")
+	}
+}
+
+func TestWaitForDependenciesWaitsForFileAndHTTP(t *testing.T) {
+	tmpDir := t.TempDir()
+	readyFile := filepath.Join(tmpDir, "ready.txt")
+
+	var mu sync.Mutex
+	requestCount := 0
+	var seenHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		requestCount++
+		seenHeader = r.Header.Get("X-Test")
+		if requestCount == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	httpURL, err := url.Parse(server.URL)
+	assert.NoError(t, err)
+	fileURL := url.URL{Scheme: "file", Path: readyFile}
+
+	oldURLs := urls
+	oldHeaders := headers
+	oldWaitFlag := waitFlag
+	oldRetry := waitRetryInterval
+	oldTimeout := waitTimeoutFlag
+	urls = []url.URL{fileURL, *httpURL}
+	headers = []HttpHeader{{name: "X-Test", value: "value"}}
+	waitFlag = hostFlagsVar{"file://" + readyFile, server.URL}
+	wg = sync.WaitGroup{}
+	waitRetryInterval = 10 * time.Millisecond
+	waitTimeoutFlag = time.Second
+	defer func() {
+		urls = oldURLs
+		headers = oldHeaders
+		waitFlag = oldWaitFlag
+		wg = sync.WaitGroup{}
+		waitRetryInterval = oldRetry
+		waitTimeoutFlag = oldTimeout
+	}()
+
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		_ = os.WriteFile(readyFile, []byte("ready"), 0o644)
+	}()
+
+	waitForDependencies()
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.GreaterOrEqual(t, requestCount, 2)
+	assert.Equal(t, "value", seenHeader)
+}
+
+func TestSignalProcessWithTimeoutPassesSignal(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "sleep 10")
+	err := cmd.Start()
+	assert.NoError(t, err)
+
+	signalProcessWithTimeout(cmd, syscall.SIGTERM)
+	assert.NotNil(t, cmd.ProcessState)
+	assert.NotNil(t, cmd.Process)
+	err = cmd.Process.Signal(syscall.Signal(0))
+	assert.Error(t, err)
+}
+
+func TestRunCmdCancelsContextWhenCommandExits(t *testing.T) {
+	ctx, cancelFn := context.WithCancel(context.Background())
+	defer cancelFn()
+
+	wg = sync.WaitGroup{}
+	defer func() {
+		wg = sync.WaitGroup{}
+	}()
+
+	wg.Add(1)
+	go runCmd(ctx, cancelFn, "sh", "-c", "exit 0")
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected command completion to cancel context")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for runCmd goroutines")
+	}
 }

--- a/tail_test.go
+++ b/tail_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTailFileWritesAppendedLines(t *testing.T) {
+	tailDir := t.TempDir()
+	sourcePath := filepath.Join(tailDir, "source.log")
+	destPath := filepath.Join(tailDir, "dest.log")
+
+	if err := os.WriteFile(sourcePath, []byte{}, 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
+	dest, err := os.Create(destPath)
+	if err != nil {
+		t.Fatalf("create dest file: %v", err)
+	}
+	defer dest.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	wg.Add(1)
+	go tailFile(ctx, sourcePath, true, dest)
+
+	appended := []string{"first line", "second line"}
+	for _, line := range appended {
+		f, err := os.OpenFile(sourcePath, os.O_APPEND|os.O_WRONLY, 0o644)
+		if err != nil {
+			t.Fatalf("open source for append: %v", err)
+		}
+		if _, err := f.WriteString(line + "\n"); err != nil {
+			f.Close()
+			t.Fatalf("append source line: %v", err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatalf("close source file: %v", err)
+		}
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		got, err := os.ReadFile(destPath)
+		if err != nil {
+			cancel()
+			wg.Wait()
+			t.Fatalf("read dest file: %v", err)
+		}
+		if strings.Split(strings.TrimSpace(string(got)), "\n")[0] == appended[0] && strings.Contains(string(got), appended[1]) {
+			break
+		}
+		if time.Now().After(deadline) {
+			cancel()
+			wg.Wait()
+			t.Fatalf("timed out waiting for tailed lines, got %q", string(got))
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	cancel()
+	wg.Wait()
+
+	got, err := os.ReadFile(destPath)
+	if err != nil {
+		t.Fatalf("read final dest file: %v", err)
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(string(got)))
+	var lines []string
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan dest file: %v", err)
+	}
+	if len(lines) != len(appended) {
+		t.Fatalf("expected %d tailed lines, got %d (%q)", len(appended), len(lines), string(got))
+	}
+	for i, want := range appended {
+		if lines[i] != want {
+			t.Fatalf("line %d mismatch: got %q want %q", i, lines[i], want)
+		}
+	}
+}
+
+func TestTailFileStopsWhenContextCanceled(t *testing.T) {
+	tailDir := t.TempDir()
+	sourcePath := filepath.Join(tailDir, "source.log")
+	destPath := filepath.Join(tailDir, "dest.log")
+
+	if err := os.WriteFile(sourcePath, []byte{}, 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
+	dest, err := os.Create(destPath)
+	if err != nil {
+		t.Fatalf("create dest file: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	wg.Add(1)
+	go tailFile(ctx, sourcePath, true, dest)
+
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("tailFile did not stop after context cancellation")
+	}
+
+	if err := dest.Close(); err != nil {
+		t.Fatalf("close dest file: %v", err)
+	}
+
+	got, err := os.ReadFile(destPath)
+	if err != nil {
+		t.Fatalf("read dest file: %v", err)
+	}
+	if string(got) != "" {
+		t.Fatalf("expected no tailed output, got %q", string(got))
+	}
+}

--- a/template_test.go
+++ b/template_test.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGenerateFileRendersTemplateFunctions(t *testing.T) {
+	oldDelims := delims
+	oldNoOverwrite := noOverwriteFlag
+	defer func() {
+		delims = oldDelims
+		noOverwriteFlag = oldNoOverwrite
+	}()
+
+	delims = nil
+	noOverwriteFlag = false
+
+	tempDir := t.TempDir()
+	templatePath := filepath.Join(tempDir, "config.tmpl")
+	destPath := filepath.Join(tempDir, "config.out")
+
+	templateContent := `{{ default nil "fallback" }}|{{ add 2 3 }}|{{ lower "MiXeD" }}|{{ upper "MiXeD" }}|{{ isTrue "yes" }}|{{ jsonQuery "{\"name\":\"dockerize\"}" "name" }}|{{ range $i := loop 1 4 }}{{ $i }}{{ end }}`
+	if err := os.WriteFile(templatePath, []byte(templateContent), 0o644); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+
+	if ok := generateFile(templatePath, destPath); !ok {
+		t.Fatalf("generateFile returned false")
+	}
+
+	got, err := os.ReadFile(destPath)
+	if err != nil {
+		t.Fatalf("read rendered file: %v", err)
+	}
+
+	want := "fallback|5|mixed|MIXED|true|dockerize|123"
+	if string(got) != want {
+		t.Fatalf("rendered output mismatch: got %q want %q", string(got), want)
+	}
+}
+
+func TestGenerateFileUsesCustomDelimiters(t *testing.T) {
+	oldDelims := delims
+	oldNoOverwrite := noOverwriteFlag
+	defer func() {
+		delims = oldDelims
+		noOverwriteFlag = oldNoOverwrite
+	}()
+
+	delims = []string{"[[", "]]"}
+	noOverwriteFlag = false
+
+	tempDir := t.TempDir()
+	templatePath := filepath.Join(tempDir, "custom.tmpl")
+	destPath := filepath.Join(tempDir, "custom.out")
+
+	if err := os.WriteFile(templatePath, []byte(`[[ add 7 8 ]]`), 0o644); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+
+	if ok := generateFile(templatePath, destPath); !ok {
+		t.Fatalf("generateFile returned false")
+	}
+
+	got, err := os.ReadFile(destPath)
+	if err != nil {
+		t.Fatalf("read rendered file: %v", err)
+	}
+
+	if string(got) != "15" {
+		t.Fatalf("rendered output mismatch: got %q want %q", string(got), "15")
+	}
+}
+
+func TestGenerateFileNoOverwrite(t *testing.T) {
+	oldDelims := delims
+	oldNoOverwrite := noOverwriteFlag
+	defer func() {
+		delims = oldDelims
+		noOverwriteFlag = oldNoOverwrite
+	}()
+
+	delims = nil
+	noOverwriteFlag = true
+
+	tempDir := t.TempDir()
+	templatePath := filepath.Join(tempDir, "skip.tmpl")
+	destPath := filepath.Join(tempDir, "skip.out")
+
+	if err := os.WriteFile(templatePath, []byte(`new-content`), 0o644); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+	if err := os.WriteFile(destPath, []byte("existing-content"), 0o644); err != nil {
+		t.Fatalf("write existing dest: %v", err)
+	}
+
+	if ok := generateFile(templatePath, destPath); ok {
+		t.Fatalf("generateFile returned true, want false when no-overwrite is enabled")
+	}
+
+	got, err := os.ReadFile(destPath)
+	if err != nil {
+		t.Fatalf("read destination file: %v", err)
+	}
+
+	if string(got) != "existing-content" {
+		t.Fatalf("destination file was overwritten: got %q", string(got))
+	}
+}
+
+func TestGenerateDirRendersAllTemplates(t *testing.T) {
+	oldDelims := delims
+	oldNoOverwrite := noOverwriteFlag
+	defer func() {
+		delims = oldDelims
+		noOverwriteFlag = oldNoOverwrite
+	}()
+
+	delims = nil
+	noOverwriteFlag = false
+
+	tempDir := t.TempDir()
+	templateDir := filepath.Join(tempDir, "templates")
+	destDir := filepath.Join(tempDir, "rendered")
+
+	if err := os.Mkdir(templateDir, 0o755); err != nil {
+		t.Fatalf("mkdir template dir: %v", err)
+	}
+	if err := os.Mkdir(destDir, 0o755); err != nil {
+		t.Fatalf("mkdir dest dir: %v", err)
+	}
+
+	files := map[string]string{
+		"one.txt": `{{ add 1 1 }}`,
+		"two.txt": `{{ upper "two" }}`,
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(templateDir, name), []byte(content), 0o644); err != nil {
+			t.Fatalf("write template %s: %v", name, err)
+		}
+	}
+
+	if ok := generateDir(templateDir, destDir); !ok {
+		t.Fatalf("generateDir returned false")
+	}
+
+	checks := map[string]string{
+		"one.txt": "2",
+		"two.txt": "TWO",
+	}
+	for name, want := range checks {
+		got, err := os.ReadFile(filepath.Join(destDir, name))
+		if err != nil {
+			t.Fatalf("read rendered file %s: %v", name, err)
+		}
+		if string(got) != want {
+			t.Fatalf("rendered output mismatch for %s: got %q want %q", name, string(got), want)
+		}
+	}
+}


### PR DESCRIPTION
## What was changed

Added comprehensive unit tests across three packages:
- `main_test.go` (156 lines)
- `tail_test.go` (136 lines)
- `template_test.go` (162 lines)

## Why

Test coverage across these packages was insufficient, making it difficult to catch regressions and verify correctness of existing functionality. This addresses the low test coverage finding by adding 454 lines of new test code.

## How to verify

Run the test suite and confirm all new tests pass:

```sh
go test ./...
```

Verify improved coverage with:

```sh
go test -cover ./...
```