### PR TITLE
Disable credential persistence in CI checkout step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@v6


### PR DESCRIPTION
## What Changed
Added `persist-credentials: false` to the `actions/checkout` step in `.github/workflows/ci.yml`.

## Why
By default, `actions/checkout` writes the GitHub token into the local `.git/config` after cloning. That credential then remains available to every subsequent step in the job—and to any scripts, tools, or dependencies those steps invoke. Since this workflow only needs to fetch the source to build and test, persisting the token is unnecessary and widens the attack surface for credential leakage (e.g., via a compromised dependency or third-party action). Disabling persistence addresses the "Checkout persists credentials unnecessarily" finding.

## How to Verify
1. Trigger the CI workflow on this branch and confirm the checkout step and all downstream steps complete successfully.
2. (Optional) Add a temporary debug step after checkout running `git config --local --list` and confirm no `http.<host>.extraheader` / token entry is present.
3. Review the diff to confirm `persist-credentials: false` is set on the checkout step.