### PR TITLE
Include operation target in error messages for debugging

### DIFF
--- a/main.go
+++ b/main.go
@@ -268,11 +268,11 @@ func main() {
 		if strings.Contains(h, ":") {
 			parts := strings.Split(h, ":")
 			if len(parts) != 2 {
-				log.Fatalf(errMsg, headersFlag)
+				log.Fatalf(errMsg, h)
 			}
 			headers = append(headers, HttpHeader{name: strings.TrimSpace(parts[0]), value: strings.TrimSpace(parts[1])})
 		} else {
-			log.Fatalf(errMsg, headersFlag)
+			log.Fatalf(errMsg, h)
 		}
 
 	}

--- a/template.go
+++ b/template.go
@@ -151,7 +151,7 @@ func generateFile(templatePath, destPath string) bool {
 	}
 	tmpl, err := tmpl.ParseFiles(templatePath)
 	if err != nil {
-		log.Fatalf("unable to parse template: %s", err)
+		log.Fatalf("unable to parse template %s, error: %s", templatePath, err)
 	}
 
 	// Don't overwrite destination file if it exists and no-overwrite flag passed
@@ -163,14 +163,14 @@ func generateFile(templatePath, destPath string) bool {
 	if destPath != "" {
 		dest, err = os.Create(destPath)
 		if err != nil {
-			log.Fatalf("unable to create %s", err)
+			log.Fatalf("unable to create %s, error: %s", destPath, err)
 		}
 		defer dest.Close()
 	}
 
 	err = tmpl.ExecuteTemplate(dest, filepath.Base(templatePath), &Context{})
 	if err != nil {
-		log.Fatalf("template error: %s\n", err)
+		log.Fatalf("template error %s, error: %s\n", templatePath, err)
 	}
 
 	if fi, err := os.Stat(destPath); err == nil {


### PR DESCRIPTION
## What changed
Updated error messages in `main.go` and `template.go` to consistently include the operation target (the file, path, or identifier the operation was acting on). Previously, some errors omitted this context while others included it.

## Why
When an operation failed, several error messages reported only that something went wrong without naming the specific target involved. This forced developers to guess which file or resource triggered the failure, making debugging slow and error-prone—especially when the same operation runs over multiple targets. This change addresses 1 finding where the target was missing, bringing those messages in line with the rest of the codebase.

## How to verify
1. Trigger a failing operation in the affected code paths (e.g., point at a non-existent or invalid target).
2. Confirm the resulting error message now names the specific operation target.
3. Review the diff in `main.go` and `template.go` to confirm only the error-message strings were updated and the included target matches the operation's input.