### PR TITLE
Fix waitForSocket to honor its timeout parameter

### DIFF
--- a/main.go
+++ b/main.go
@@ -175,7 +175,7 @@ func waitForSocket(scheme, addr string, timeout time.Duration) {
 	go func() {
 		defer wg.Done()
 		for {
-			conn, err := dialTimeout(scheme, addr, waitTimeoutFlag)
+			conn, err := dialTimeout(scheme, addr, timeout)
 			if err != nil {
 				log.Printf("Problem with dial: %v. Sleeping %s\n", err.Error(), waitRetryInterval)
 				time.Sleep(waitRetryInterval)

--- a/main.go
+++ b/main.go
@@ -56,6 +56,7 @@ var (
 	waitRetryInterval time.Duration
 	waitTimeoutFlag   time.Duration
 	noOverwriteFlag   bool
+	dialTimeout       = net.DialTimeout
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -174,7 +175,7 @@ func waitForSocket(scheme, addr string, timeout time.Duration) {
 	go func() {
 		defer wg.Done()
 		for {
-			conn, err := net.DialTimeout(scheme, addr, waitTimeoutFlag)
+			conn, err := dialTimeout(scheme, addr, waitTimeoutFlag)
 			if err != nil {
 				log.Printf("Problem with dial: %v. Sleeping %s\n", err.Error(), waitRetryInterval)
 				time.Sleep(waitRetryInterval)

--- a/main_test.go
+++ b/main_test.go
@@ -157,6 +157,50 @@ func TestLoop(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestWaitForSocketUsesPassedTimeoutForDial(t *testing.T) {
+	oldDialTimeout := dialTimeout
+	oldTimeout := waitTimeoutFlag
+	oldRetry := waitRetryInterval
+	wg = sync.WaitGroup{}
+	waitTimeoutFlag = 200 * time.Millisecond
+	waitRetryInterval = 10 * time.Millisecond
+	defer func() {
+		dialTimeout = oldDialTimeout
+		waitTimeoutFlag = oldTimeout
+		waitRetryInterval = oldRetry
+		wg = sync.WaitGroup{}
+	}()
+
+	timeoutArg := make(chan time.Duration, 1)
+	dialTimeout = func(network, address string, timeout time.Duration) (net.Conn, error) {
+		timeoutArg <- timeout
+		client, server := net.Pipe()
+		go server.Close()
+		return client, nil
+	}
+
+	waitForSocket("tcp", "example:1234", 75*time.Millisecond)
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for socket connection")
+	}
+
+	select {
+	case got := <-timeoutArg:
+		assert.Equal(t, 75*time.Millisecond, got)
+	case <-time.After(time.Second):
+		t.Fatal("dial timeout was not recorded")
+	}
+}
+
 func TestWaitForSocketConnectsToTCPServer(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	assert.NoError(t, err)
@@ -164,6 +208,7 @@ func TestWaitForSocketConnectsToTCPServer(t *testing.T) {
 
 	oldRetry := waitRetryInterval
 	oldTimeout := waitTimeoutFlag
+	oldDialTimeout := dialTimeout
 	wg = sync.WaitGroup{}
 	waitRetryInterval = 10 * time.Millisecond
 	waitTimeoutFlag = 200 * time.Millisecond
@@ -171,6 +216,7 @@ func TestWaitForSocketConnectsToTCPServer(t *testing.T) {
 		wg = sync.WaitGroup{}
 		waitRetryInterval = oldRetry
 		waitTimeoutFlag = oldTimeout
+		dialTimeout = oldDialTimeout
 	}()
 
 	acceptDone := make(chan struct{})


### PR DESCRIPTION
## What changed
`waitForSocket` was referencing a package-level/global timeout value instead of the `timeout` argument passed to it. This change updates the function to use its own `timeout` parameter when waiting for the socket.

## Why
Because the function ignored its parameter, every caller effectively got the global timeout regardless of what they requested. This made the parameter misleading and prevented callers from specifying shorter or longer waits per invocation, leading to incorrect timeout behavior.

## How to verify
- Run the test suite: `go test ./...`
- The newly added test in `main_test.go` exercises `waitForSocket` with an explicit timeout value and asserts that the passed-in timeout is respected (rather than the global). The test fails against the previous implementation and passes with this fix.