### PR TITLE
Include operation target (host/URL) in error messages

### DIFF
--- a/main.go
+++ b/main.go
@@ -126,7 +126,7 @@ func waitForDependencies() {
 					for {
 						req, err := http.NewRequest("GET", u.String(), nil)
 						if err != nil {
-							log.Printf("Problem with dial: %v. Sleeping %s\n", err.Error(), waitRetryInterval)
+							log.Printf("Problem with request %s: %v. Sleeping %s\n", u.String(), err.Error(), waitRetryInterval)
 							time.Sleep(waitRetryInterval)
 						}
 						if len(headers) > 0 {
@@ -137,7 +137,7 @@ func waitForDependencies() {
 
 						resp, err := client.Do(req)
 						if err != nil {
-							log.Printf("Problem with request: %s. Sleeping %s\n", err.Error(), waitRetryInterval)
+							log.Printf("Problem with request %s: %s. Sleeping %s\n", u.String(), err.Error(), waitRetryInterval)
 							time.Sleep(waitRetryInterval)
 						} else if err == nil && resp.StatusCode >= 200 && resp.StatusCode < 300 {
 							log.Printf("Received %d from %s\n", resp.StatusCode, u.String())
@@ -177,7 +177,7 @@ func waitForSocket(scheme, addr string, timeout time.Duration) {
 		for {
 			conn, err := dialTimeout(scheme, addr, timeout)
 			if err != nil {
-				log.Printf("Problem with dial: %v. Sleeping %s\n", err.Error(), waitRetryInterval)
+				log.Printf("Problem with dial %s://%s: %v. Sleeping %s\n", scheme, addr, err.Error(), waitRetryInterval)
 				time.Sleep(waitRetryInterval)
 			}
 			if conn != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"log"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -9,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"syscall"
 	"testing"
@@ -199,6 +203,43 @@ func TestWaitForSocketUsesPassedTimeoutForDial(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("dial timeout was not recorded")
 	}
+}
+
+func TestWaitForSocketLogsDialTarget(t *testing.T) {
+	oldDialTimeout := dialTimeout
+	oldRetry := waitRetryInterval
+	oldOutput := log.Writer()
+	wg = sync.WaitGroup{}
+	waitRetryInterval = 10 * time.Millisecond
+	defer func() {
+		dialTimeout = oldDialTimeout
+		waitRetryInterval = oldRetry
+		log.SetOutput(oldOutput)
+		wg = sync.WaitGroup{}
+	}()
+
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+
+	dialErr := errors.New("dial failed")
+	dialDone := make(chan struct{}, 1)
+	dialTimeout = func(network, address string, timeout time.Duration) (net.Conn, error) {
+		select {
+		case dialDone <- struct{}{}:
+		default:
+		}
+		return nil, dialErr
+	}
+
+	waitForSocket("tcp", "example:1234", 75*time.Millisecond)
+
+	select {
+	case <-dialDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for dial attempt")
+	}
+
+	assert.Contains(t, strings.TrimSpace(buf.String()), "Problem with dial tcp://example:1234: dial failed")
 }
 
 func TestWaitForSocketConnectsToTCPServer(t *testing.T) {


### PR DESCRIPTION
## What changed
Updated error messages in `main.go` to include the operation's target (host/URL) when reporting failures. Previously these messages omitted the target, while the rest of the codebase consistently includes it. Added test coverage in `main_test.go` to assert the target now appears in the generated error output.

## Why
Error messages in a couple of spots were inconsistent with the convention used everywhere else, which always identifies the host/URL involved in a failed operation. Without the target, these errors are harder to diagnose because the reader cannot tell which host or URL the failure relates to. This change restores consistency and makes the errors actionable.

## How to verify
1. Run the test suite: `go test ./...`
2. Confirm the new assertions in `main_test.go` pass and fail without the `main.go` change (the added test demonstrates the bug by checking that the host/URL is present in the error message).
3. Optionally, trigger one of the affected error paths manually and confirm the emitted message now includes the host/URL.