### PR TITLE
Fix unchecked type assertion in defaultValue template function

### DIFF
--- a/template.go
+++ b/template.go
@@ -40,7 +40,9 @@ func defaultValue(args ...interface{}) (string, error) {
 
 	if len(args) > 0 {
 		if args[0] != nil {
-			return args[0].(string), nil
+			if s, ok := args[0].(string); ok {
+				return s, nil
+			}
 		}
 	}
 

--- a/template_test.go
+++ b/template_test.go
@@ -110,6 +110,34 @@ func TestGenerateFileNoOverwrite(t *testing.T) {
 	}
 }
 
+func TestGenerateFileDefaultDoesNotPanicOnNonStringValue(t *testing.T) {
+	oldDelims := delims
+	oldNoOverwrite := noOverwriteFlag
+	defer func() {
+		delims = oldDelims
+		noOverwriteFlag = oldNoOverwrite
+	}()
+
+	delims = nil
+	noOverwriteFlag = false
+
+	tempDir := t.TempDir()
+	templatePath := filepath.Join(tempDir, "default-non-string.tmpl")
+	destPath := filepath.Join(tempDir, "default-non-string.out")
+
+	if err := os.WriteFile(templatePath, []byte(`{{ default (add 1 2) "fallback" }}`), 0o644); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("generateFile panicked: %v", r)
+		}
+	}()
+
+	generateFile(templatePath, destPath)
+}
+
 func TestGenerateDirRendersAllTemplates(t *testing.T) {
 	oldDelims := delims
 	oldNoOverwrite := noOverwriteFlag


### PR DESCRIPTION
## What changed

This PR fixes an unchecked type assertion in the `defaultValue` template function in `template.go`. The type assertion now uses the two-value form (the "comma ok" idiom) so that a failed assertion is handled gracefully instead of triggering a runtime panic.

## Why

The previous code performed a single-value type assertion on the input value. When the value did not match the expected type, the assertion panicked, which could crash template rendering at runtime. Validating the assertion before using the result prevents this panic and allows the function to fall back to the default value safely.

## How to verify

- Run the test suite: `go test ./...`
- A new test case in `template_test.go` exercises the `defaultValue` function with a value whose type does not match the expected assertion. This test fails (panics) against the original code and passes with the fix in place.