### PR TITLE
Preallocate map with size hint to reduce reallocations

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ type HttpHeader struct {
 }
 
 func (c *Context) Env() map[string]string {
-	env := make(map[string]string)
+	env := make(map[string]string, len(os.Environ()))
 	for _, i := range os.Environ() {
 		sep := strings.Index(i, "=")
 		env[i[0:sep]] = i[sep+1:]

--- a/main_test.go
+++ b/main_test.go
@@ -63,6 +63,28 @@ func TestContains(t *testing.T) {
 	assert.False(t, contains(testMap, "key3"))
 }
 
+func TestContextEnvReturnsCurrentEnvironment(t *testing.T) {
+	ctx := &Context{}
+	env := ctx.Env()
+	expected := make(map[string]string)
+
+	for _, entry := range os.Environ() {
+		sep := -1
+		for i := 0; i < len(entry); i++ {
+			if entry[i] == '=' {
+				sep = i
+				break
+			}
+		}
+		if sep == -1 {
+			t.Fatalf("environment entry missing '=': %q", entry)
+		}
+		expected[entry[:sep]] = entry[sep+1:]
+	}
+
+	assert.Equal(t, expected, env)
+}
+
 func TestDefaultValue(t *testing.T) {
 	result, err := defaultValue("test-value")
 	assert.NoError(t, err)


### PR DESCRIPTION
## What
Added a size hint to the `make(map[...])` call in `main.go` so the map is preallocated with its expected capacity. Also extended `main_test.go` with a test that exercises the populated map and guards the behavior.

## Why
Creating a map without a size hint causes Go to grow the underlying hash table incrementally as entries are inserted, triggering repeated reallocations and rehashing. When the approximate number of elements is known up front, passing a capacity to `make` avoids this churn, reducing allocations and improving insertion performance. This addresses the single finding flagged for this change (map created without size hint).

## How to verify
1. Review the `make(map[...], n)` call in `main.go` to confirm the size hint matches the expected element count.
2. Run the tests:
   ```
   go test ./...
   ```
   The new/updated cases in `main_test.go` should pass, confirming the map is populated correctly with the preallocated capacity.
3. (Optional) Benchmark or profile the affected path to observe fewer allocations compared to the previous unsized map.