### PR TITLE
ci: add timeout limits to CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -37,6 +38,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -61,6 +63,7 @@ jobs:
   vulncheck:
     name: Vulnerability Check
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -80,6 +83,7 @@ jobs:
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -95,6 +99,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [lint, test, vulncheck, e2e]
     strategy:
       matrix:


### PR DESCRIPTION
## What Changed

Added `timeout-minutes` limits to the jobs defined in `.github/workflows/ci.yml`. This change introduces 5 lines to enforce explicit execution time boundaries on CI workflow jobs.

## Why

Previously, CI jobs had no timeout configured. Without an explicit `timeout-minutes` value, GitHub Actions applies a default maximum of 6 hours (360 minutes) per job. This means a hung, stuck, or runaway job (e.g., one waiting on a deadlocked process, infinite loop, or unresponsive network resource) could run for hours before being terminated. This:

- Wastes CI runner minutes and increases costs.
- Delays feedback to developers waiting on the queue.
- Can block other jobs if runner capacity is exhausted.

Adding explicit timeouts ensures jobs fail fast when something goes wrong, freeing up resources and surfacing problems quickly.

## How to Verify

1. Review the updated `.github/workflows/ci.yml` and confirm each job now declares a `timeout-minutes` value.
2. Confirm the CI pipeline still runs and passes successfully on this PR (normal job durations should be well under the configured limits).
3. Optionally, validate the workflow syntax locally (e.g., with `actionlint`) or confirm GitHub does not report any workflow parsing errors.