### PR TITLE
Fix inconsistent error handling in main.go and template.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -103,7 +104,7 @@ func waitForDependencies() {
 						if _, err = os.Stat(u.Path); err == nil {
 							log.Printf("File %s had been generated\n", u.String())
 							return
-						} else if os.IsNotExist(err) {
+						} else if errors.Is(err, os.ErrNotExist) {
 							continue
 						} else {
 							log.Printf("Problem with check file %s exist: %v. Sleeping %s\n", u.String(), err.Error(), waitRetryInterval)

--- a/template.go
+++ b/template.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"net/url"
@@ -20,7 +21,7 @@ func exists(path string) (bool, error) {
 	if err == nil {
 		return true, nil
 	}
-	if os.IsNotExist(err) {
+	if errors.Is(err, os.ErrNotExist) {
 		return false, nil
 	}
 	return false, err


### PR DESCRIPTION
## What Changed
Standardized the error handling pattern across `main.go` and `template.go` to align with the rest of the codebase. This addresses 1 finding related to inconsistent error handling patterns, touching 2 lines (4 insertions, 2 deletions across both files).

## Why
The affected lines used an error handling approach that diverged from the convention used elsewhere in the project. Inconsistent patterns make the code harder to read, review, and maintain, and can mask or obscure how errors propagate. Bringing these call sites in line with the established pattern improves consistency and reduces the risk of mishandled errors.

## How to Verify
1. Build the project to confirm it compiles cleanly:
   ```
   go build ./...
   ```
2. Run the existing test suite to ensure no regressions:
   ```
   go test ./...
   ```
3. Run static analysis / linting to confirm the error-handling finding no longer reports:
   ```
   go vet ./...
   ```
4. Review the diff in `main.go` and `template.go` to confirm the updated lines follow the same error handling convention used throughout the codebase.