### PR TITLE
refactor: remove untrappable SIGKILL from signal.Notify

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -28,7 +28,7 @@ func runCmd(ctx context.Context, cancel context.CancelFunc, cmd string, args ...
 
 	// Setup signaling
 	sigs := make(chan os.Signal, 1)
-	signal.Notify(sigs, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGKILL)
+	signal.Notify(sigs, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM)
 
 	wg.Add(1)
 	go func() {


### PR DESCRIPTION
SIGKILL cannot be caught, blocked, or ignored by any process (it is handled directly by the kernel). Including it in `signal.Notify` is a no-op that misleads readers into thinking the application handles SIGKILL gracefully. Removing it clarifies the actual signal handling behavior.

Detected by staticcheck SA1016.