### PR TITLE
ci: add -race flag to e2e test step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Run e2e tests
-        run: go test -v -timeout 120s ./e2e/
+        run: go test -v -race -timeout 120s ./e2e/
 
   build:
     name: Build


### PR DESCRIPTION
The unit test job already runs with `-race`, but the e2e tests did not. This adds it so data races are caught in integration tests as well.