### PR TITLE
Fix header and template parsing to preserve colons in values

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -391,8 +391,11 @@ func TestWaitMultiple(t *testing.T) {
 }
 
 func TestWaitHTTPHeader(t *testing.T) {
+	receivedHeader := make(chan string, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("X-Custom-Auth") == "secret123" {
+		headerValue := r.Header.Get("X-Custom-Auth")
+		receivedHeader <- headerValue
+		if headerValue == "secret123" {
 			w.WriteHeader(200)
 		} else {
 			w.WriteHeader(401)
@@ -408,6 +411,56 @@ func TestWaitHTTPHeader(t *testing.T) {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("dockerize failed: %v\n%s", err, out)
+	}
+
+	select {
+	case got := <-receivedHeader:
+		if got != "secret123" {
+			t.Fatalf("expected header value %q, got %q", "secret123", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for HTTP request")
+	}
+
+	if !strings.Contains(string(out), "authed") {
+		t.Fatalf("expected 'authed' in output, got: %s", string(out))
+	}
+}
+
+func TestWaitHTTPHeaderValueWithAdditionalColons(t *testing.T) {
+	const expectedValue = "Bearer part1:part2:part3"
+	receivedHeader := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		headerValue := r.Header.Get("X-Custom-Auth")
+		select {
+		case receivedHeader <- headerValue:
+		default:
+		}
+		if headerValue == expectedValue {
+			w.WriteHeader(200)
+		} else {
+			w.WriteHeader(401)
+		}
+	}))
+	defer srv.Close()
+
+	cmd := exec.Command(dockerizeBin,
+		"-wait", srv.URL,
+		"-wait-http-header", "X-Custom-Auth: "+expectedValue,
+		"-timeout", "5s",
+		"echo", "authed")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("dockerize failed: %v\n%s", err, out)
+	}
+
+	select {
+	case got := <-receivedHeader:
+		if got != expectedValue {
+			t.Fatalf("expected header value %q, got %q", expectedValue, got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for HTTP request")
 	}
 
 	if !strings.Contains(string(out), "authed") {

--- a/main.go
+++ b/main.go
@@ -268,7 +268,7 @@ func main() {
 
 		const errMsg = "bad HTTP Headers argument: %s. expected \"headerName: headerValue\""
 		if strings.Contains(h, ":") {
-			parts := strings.Split(h, ":")
+			parts := strings.SplitN(h, ":", 2)
 			if len(parts) != 2 {
 				log.Fatalf(errMsg, h)
 			}
@@ -282,7 +282,7 @@ func main() {
 	for _, t := range templatesFlag {
 		template, dest := t, ""
 		if strings.Contains(t, ":") {
-			parts := strings.Split(t, ":")
+			parts := strings.SplitN(t, ":", 2)
 			if len(parts) != 2 {
 				log.Fatalf("bad template argument: %s. expected \"/template:/dest\"", t)
 			}


### PR DESCRIPTION
## Changes

- **main.go**: Replace `strings.Split(h, ":")` with `strings.SplitN(h, ":", 2)` in the `-wait-http-header` parsing block so header values containing additional colons (e.g. `Bearer token:part2:part3`) are preserved intact. Same fix applied to `-template` flag parsing.

- **e2e/e2e_test.go**: Add `TestWaitHTTPHeaderValueWithAdditionalColons` regression test that verifies an HTTP header value containing multiple colons is received by the server without truncation.

## Verification

```
go test -v -run TestWaitHTTPHeader ./e2e/
```