### PR TITLE
Disable credential persistence in GitHub Actions checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -87,6 +89,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -108,6 +112,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@v6


### PR DESCRIPTION
## What changed
Added `persist-credentials: false` to every `actions/checkout@v6` step in:
- `.github/workflows/ci.yml`
- `.github/workflows/codeql.yml`

## Why
This fixes the finding that checkout was persisting repository credentials in workflow jobs even though these jobs only need read access to fetch source code. Disabling credential persistence reduces unnecessary credential exposure in CI and CodeQL runs.

## How to verify
- Review both workflow files and confirm each `actions/checkout@v6` step sets `persist-credentials: false`.
- Run or inspect the CI and CodeQL workflows to confirm they still complete successfully with checkout, build, test, lint, vulncheck, e2e, and analysis steps unchanged.