### PR TITLE
Bump Go from 1.25.11 to 1.25.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.11 AS binary
+FROM golang:1.25.12 AS binary
 
 WORKDIR /go/src/github.com/jwilder/dockerize
 COPY *.go go.* /go/src/github.com/jwilder/dockerize/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jwilder/dockerize
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0


### PR DESCRIPTION
Addresses the below CVEs:
CVE-2026-39822
CVE-2026-42505